### PR TITLE
Implement support for slash commands

### DIFF
--- a/JDA-Utilities-Patches/0012-Slash-command-support.patch
+++ b/JDA-Utilities-Patches/0012-Slash-command-support.patch
@@ -1,4 +1,4 @@
-From 19e8ab8429d140ae59ddcd12f20854908ce8640a Mon Sep 17 00:00:00 2001
+From 83629614a24ed83e51b3a26165f24f80e2db08a5 Mon Sep 17 00:00:00 2001
 From: Chew <chew@chew.pw>
 Date: Sun, 23 May 2021 17:46:44 -0500
 Subject: [PATCH] Slash command support
@@ -371,7 +371,7 @@ index f4658a8..ed93f17 100644
  }
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
 new file mode 100644
-index 0000000..cb80ade
+index 0000000..fa196c9
 --- /dev/null
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
 @@ -0,0 +1,638 @@
@@ -862,7 +862,7 @@ index 0000000..cb80ade
 +                // Create subcommand data
 +                SubcommandData subcommandData = new SubcommandData(child.getName(), child.getHelp());
 +                // Add options
-+                if (!getOptions().isEmpty())
++                if (!child.getOptions().isEmpty())
 +                {
 +                    subcommandData.addOptions(child.getOptions());
 +                }

--- a/JDA-Utilities-Patches/0012-Slash-command-support.patch
+++ b/JDA-Utilities-Patches/0012-Slash-command-support.patch
@@ -1,4 +1,4 @@
-From 36fbf5d58fd84bbe7572bf4f127cfe562c67737f Mon Sep 17 00:00:00 2001
+From bc6830c1548f9e8853db4124cc349e8e1c0dffa8 Mon Sep 17 00:00:00 2001
 From: Chew <chew@chew.pw>
 Date: Sun, 23 May 2021 17:46:44 -0500
 Subject: [PATCH] Slash command support
@@ -1071,7 +1071,7 @@ index 0000000..0abf860
 +    }
 +}
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
-index 5a5e7d2..b981dc6 100644
+index 5a5e7d2..3976bb8 100644
 --- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
 @@ -28,9 +28,12 @@ import net.dv8tion.jda.api.events.ReadyEvent;
@@ -1167,19 +1167,7 @@ index 5a5e7d2..b981dc6 100644
      @Override
      public void removeCommand(String name)
      {
-@@ -455,12 +499,21 @@ public class CommandClientImpl implements CommandClient, EventListener
-         executor.shutdown();
-     }
- 
-+    public void removeSlashCommands(JDA jda) {
-+        for (String id : slashCommandIds) {
-+            jda.deleteCommandById(id).queue();
-+        }
-+    }
-+
-     @Override
-     public void onEvent(GenericEvent event)
-     {
+@@ -461,6 +505,9 @@ public class CommandClientImpl implements CommandClient, EventListener
          if(event instanceof MessageReceivedEvent)
              onMessageReceived((MessageReceivedEvent)event);
  
@@ -1189,23 +1177,13 @@ index 5a5e7d2..b981dc6 100644
          else if(event instanceof GuildMessageDeleteEvent && usesLinkedDeletion())
              onMessageDelete((GuildMessageDeleteEvent) event);
  
-@@ -476,6 +529,7 @@ public class CommandClientImpl implements CommandClient, EventListener
-             onReady((ReadyEvent)event);
-         else if(event instanceof ShutdownEvent)
-         {
-+            removeSlashCommands(event.getJDA());
-             if(shutdownAutomatically)
-                 shutdown();
-         }
-@@ -498,6 +552,27 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -498,6 +545,23 @@ public class CommandClientImpl implements CommandClient, EventListener
          if(manager != null)
              manager.init();
  
 +        // Upsert slash commands
-+        System.out.println("Upserting slash commands");
 +        for (SlashCommand command : slashCommands)
 +        {
-+            System.out.println("Generating CommandData for " + command.getName() + ".");
 +            CommandData data = new CommandData(command.getName(), command.getHelp());
 +            if (!command.getOptions().isEmpty()) {
 +                for (OptionData optionData : command.getOptions()) {
@@ -1214,10 +1192,8 @@ index 5a5e7d2..b981dc6 100644
 +            }
 +
 +            if (command.isGuildOnly() && command.getGuildId() != null) {
-+                System.out.println("Adding command " + command.getName() + " to server " + command.getGuildId());
 +                event.getJDA().getGuildById(command.getGuildId()).upsertCommand(data).queue(command1 -> slashCommandIds.add(command1.getId()));
 +            } else {
-+                System.out.println("Adding command " + command.getName());
 +                event.getJDA().upsertCommand(data).queue(command1 -> slashCommandIds.add(command1.getId()));
 +            }
 +        }
@@ -1225,7 +1201,7 @@ index 5a5e7d2..b981dc6 100644
          sendStats(event.getJDA());
      }
  
-@@ -607,6 +682,29 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -607,6 +671,29 @@ public class CommandClientImpl implements CommandClient, EventListener
              listener.onNonCommandMessage(event);
      }
  

--- a/JDA-Utilities-Patches/0012-Slash-command-support.patch
+++ b/JDA-Utilities-Patches/0012-Slash-command-support.patch
@@ -1,4 +1,4 @@
-From d2c6ed06e0a2102d6d9a78069fb667e1f468c38b Mon Sep 17 00:00:00 2001
+From e606a0c8615d377c67decfce1cc7a25e8649281f Mon Sep 17 00:00:00 2001
 From: Chew <chew@chew.pw>
 Date: Sun, 23 May 2021 17:46:44 -0500
 Subject: [PATCH] Slash command support
@@ -249,12 +249,110 @@ index 6d0e434..939e09b 100644
      /**
       * Adds an annotated command module to the
       * {@link com.jagrosh.jdautilities.command.impl.CommandClientImpl CommandClientImpl} for this session.
+diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/CommandListener.java b/command/src/main/java/com/jagrosh/jdautilities/command/CommandListener.java
+index f4658a8..ed93f17 100644
+--- a/command/src/main/java/com/jagrosh/jdautilities/command/CommandListener.java
++++ b/command/src/main/java/com/jagrosh/jdautilities/command/CommandListener.java
+@@ -15,6 +15,7 @@
+  */
+ package com.jagrosh.jdautilities.command;
+ 
++import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+ 
+ /**
+@@ -35,6 +36,17 @@ public interface CommandListener
+      *         The Command that was triggered
+      */
+     default void onCommand(CommandEvent event, Command command) {}
++
++    /**
++     * Called when a {@link com.jagrosh.jdautilities.command.SlashCommand SlashCommand} is triggered
++     * by a {@link net.dv8tion.jda.api.events.interaction.SlashCommandEvent SlashCommandEvent}.
++     *
++     * @param  event
++     *         The SlashCommandEvent that triggered the Command
++     * @param  command
++     *         The SlashCommand that was triggered
++     */
++    default void onSlashCommand(SlashCommandEvent event, SlashCommand command) {}
+     
+     /**
+      * Called when a {@link com.jagrosh.jdautilities.command.Command Command} is triggered
+@@ -51,6 +63,22 @@ public interface CommandListener
+      *         The Command that was triggered
+      */
+     default void onCompletedCommand(CommandEvent event, Command command) {}
++
++    /**
++     * Called when a {@link com.jagrosh.jdautilities.command.SlashCommand SlashCommand} is triggered
++     * by a {@link net.dv8tion.jda.api.events.interaction.SlashCommandEvent SlashCommandEvent} after it's
++     * completed successfully.
++     *
++     * <p>Note that a <i>successfully</i> completed slash command is one that has not encountered
++     * an error or exception. Calls that do face errors should be handled by
++     * {@link CommandListener#onSlashCommandException(SlashCommandEvent, SlashCommand, Throwable) CommandListener#onSlashCommandException}
++     *
++     * @param  event
++     *         The SlashCommandEvent that triggered the Command
++     * @param  command
++     *         The SlashCommand that was triggered
++     */
++    default void onCompletedSlashCommand(SlashCommandEvent event, SlashCommand command) {}
+     
+     /**
+      * Called when a {@link com.jagrosh.jdautilities.command.Command Command} is triggered
+@@ -63,6 +91,18 @@ public interface CommandListener
+      *         The Command that was triggered
+      */
+     default void onTerminatedCommand(CommandEvent event, Command command) {}
++
++    /**
++     * Called when a {@link com.jagrosh.jdautilities.command.SlashCommand Command} is triggered
++     * by a {@link net.dv8tion.jda.api.events.interaction.SlashCommandEvent SlashCommandEvent} but is
++     * terminated before completion.
++     *
++     * @param  event
++     *         The SlashCommandEvent that triggered the Command
++     * @param  command
++     *         The SlashCommand that was triggered
++     */
++    default void onTerminatedSlashCommand(SlashCommandEvent event, SlashCommand command) {}
+     
+     /**
+      * Called when a {@link net.dv8tion.jda.api.events.message.MessageReceivedEvent MessageReceivedEvent}
+@@ -117,4 +157,25 @@ public interface CommandListener
+         // Default rethrow as a runtime exception.
+         throw throwable instanceof RuntimeException? (RuntimeException)throwable : new RuntimeException(throwable);
+     }
++
++    /**
++     * Called when a {@link com.jagrosh.jdautilities.command.SlashCommand SlashCommand}
++     * catches a {@link java.lang.Throwable Throwable} <b>during execution</b>.
++     *
++     * <p>This doesn't account for exceptions thrown during other pre-checks,
++     * and should not be treated as such!
++     *
++     * The {@link java.lang.NullPointerException NullPointerException} thrown will not be caught by this method!
++     *
++     * @param  event
++     *         The CommandEvent that triggered the Command
++     * @param  command
++     *         The Command that was triggered
++     * @param  throwable
++     *         The Throwable thrown during Command execution
++     */
++    default void onSlashCommandException(SlashCommandEvent event, SlashCommand command, Throwable throwable) {
++        // Default rethrow as a runtime exception.
++        throw throwable instanceof RuntimeException? (RuntimeException)throwable : new RuntimeException(throwable);
++    }
+ }
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
 new file mode 100644
-index 0000000..1e63795
+index 0000000..78737ec
 --- /dev/null
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
-@@ -0,0 +1,428 @@
+@@ -0,0 +1,425 @@
 +/*
 + * Copyright 2016-2018 John Grosh (jagrosh) & Kaidan Gustave (TheMonitorLizard)
 + *
@@ -506,16 +604,15 @@ index 0000000..1e63795
 +        } catch(Throwable t) {
 +            if(client.getListener() != null)
 +            {
-+                //client.getListener().onCommandException(event, this, t);
++                client.getListener().onSlashCommandException(event, this, t);
 +                return;
 +            }
 +            // otherwise we rethrow
 +            throw t;
 +        }
 +
-+        // TODO: this
-+        //if(client.getListener() != null)
-+            //client.getListener().onCompletedCommand(event, this);
++        if(client.getListener() != null)
++            client.getListener().onCompletedSlashCommand(event, this);
 +    }
 +
 +    /**
@@ -617,10 +714,8 @@ index 0000000..1e63795
 +    {
 +        if(message!=null)
 +            event.reply(message).setEphemeral(true).queue();
-+        /* To-Do I guess
 +        if(client.getListener()!=null)
-+            client.getListener().onTerminatedCommand(event, this);
-+         */
++            client.getListener().onTerminatedSlashCommand(event, this);
 +    }
 +
 +    /**
@@ -684,7 +779,7 @@ index 0000000..1e63795
 +    }
 +}
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
-index 5a5e7d2..81af25a 100644
+index 5a5e7d2..4c9a949 100644
 --- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
 @@ -28,9 +28,12 @@ import net.dv8tion.jda.api.events.ReadyEvent;
@@ -817,7 +912,7 @@ index 5a5e7d2..81af25a 100644
          sendStats(event.getJDA());
      }
  
-@@ -607,6 +674,29 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -607,6 +674,25 @@ public class CommandClientImpl implements CommandClient, EventListener
              listener.onNonCommandMessage(event);
      }
  
@@ -832,16 +927,12 @@ index 5a5e7d2..81af25a 100644
 +
 +        if(command != null)
 +        {
-+            //if(listener != null)
-+            //    listener.onCommand(cevent, command);
++            if(listener != null)
++                listener.onSlashCommand(event, command);
 +            uses.put(command.getName(), uses.getOrDefault(command.getName(), 0) + 1);
 +            command.run(event, this);
-+            return; // Command is done
++            // Command is done
 +        }
-+
-+
-+        //if(listener != null)
-+        //    listener.onNonCommandMessage(event);
 +    }
 +
      private void sendStats(JDA jda)

--- a/JDA-Utilities-Patches/0012-Slash-command-support.patch
+++ b/JDA-Utilities-Patches/0012-Slash-command-support.patch
@@ -1,0 +1,1260 @@
+From 36fbf5d58fd84bbe7572bf4f127cfe562c67737f Mon Sep 17 00:00:00 2001
+From: Chew <chew@chew.pw>
+Date: Sun, 23 May 2021 17:46:44 -0500
+Subject: [PATCH] Slash command support
+
+
+diff --git a/build.gradle b/build.gradle
+index 0b5d4e2..8d89cce 100644
+--- a/build.gradle
++++ b/build.gradle
+@@ -37,7 +37,7 @@ allprojects {
+     version = versionInfo.values().join('.')
+ 
+     ext {
+-        jdaVersion = '4.2.0_214'
++        jdaVersion = 'feature~slash-commands-SNAPSHOT'
+         slf4jVersion = '1.7.25'
+         okhttpVersion = '3.13.0'
+         findbugsVersion = '3.0.2'
+@@ -45,7 +45,7 @@ allprojects {
+         junitVersion = '4.13.1' // TODO Move to junit 5?
+ 
+         dependencies {
+-            jda = { [group: 'net.dv8tion', name: 'JDA', version: jdaVersion] }
++            jda = { [group: 'com.github.dv8fromtheworld', name: 'jda', version: jdaVersion] }
+             slf4j = { [group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion] }
+             okhttp = { [group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion] }
+             findbugs = { [group: 'com.google.code.findbugs', name: 'jsr305', version: findbugsVersion] }
+@@ -92,6 +92,9 @@ allprojects {
+ 
+     repositories {
+         jcenter()
++        maven { url 'https://jitpack.io' }
++        mavenCentral()
++        mavenLocal()
+     }
+ 
+     build {
+diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/CommandClient.java b/command/src/main/java/com/jagrosh/jdautilities/command/CommandClient.java
+index f8db009..76627dd 100644
+--- a/command/src/main/java/com/jagrosh/jdautilities/command/CommandClient.java
++++ b/command/src/main/java/com/jagrosh/jdautilities/command/CommandClient.java
+@@ -168,6 +168,63 @@ public interface CommandClient
+      */
+     void addCommand(Command command, int index);
+ 
++    /**
++     * Adds a single {@link com.jagrosh.jdautilities.command.SlashCommand SlashCommand} to this CommandClient's
++     * registered SlashCommand.
++     *
++     * <p>For CommandClient's containing 20 commands or less, command calls by users will have the bot iterate
++     * through the entire {@link java.util.ArrayList ArrayList} to find the command called. As expected, this
++     * can get fairly hefty if a bot has a lot of Commands registered to it.
++     *
++     * <p>To prevent delay a CommandClient that has more that 20 Commands registered to it will begin to use
++     * <b>indexed calls</b>.
++     * <br>Indexed calls use a {@link java.util.HashMap HashMap} which links their
++     * {@link com.jagrosh.jdautilities.command.SlashCommand#name name} to the index that which they
++     * are located at in the ArrayList they are stored.
++     *
++     * <p>This means that all insertion and removal of SlashCommands must reorganize the index maintained by the HashMap.
++     * <br>For this particular insertion, the SlashCommand provided is inserted at the end of the index, meaning it will
++     * become the "rightmost" Command in the ArrayList.
++     *
++     * @param  command
++     *         The Command to add
++     *
++     * @throws java.lang.IllegalArgumentException
++     *         If the SlashCommand provided has a name or alias that has already been registered
++     */
++    void addSlashCommand(SlashCommand command);
++
++    /**
++     * Adds a single {@link com.jagrosh.jdautilities.command.SlashCommand SlashCommand} to this CommandClient's
++     * registered Commands at the specified index.
++     *
++     * <p>For CommandClient's containing 20 commands or less, command calls by users will have the bot iterate
++     * through the entire {@link java.util.ArrayList ArrayList} to find the command called. As expected, this
++     * can get fairly hefty if a bot has a lot of Commands registered to it.
++     *
++     * <p>To prevent delay a CommandClient that has more that 20 Commands registered to it will begin to use
++     * <b>indexed calls</b>.
++     * <br>Indexed calls use a {@link java.util.HashMap HashMap} which links their
++     * {@link com.jagrosh.jdautilities.command.Command#name name} to the index that which they
++     * are located at in the ArrayList they are stored.
++     *
++     * <p>This means that all insertion and removal of Commands must reorganize the index maintained by the HashMap.
++     * <br>For this particular insertion, the Command provided is inserted at the index specified, meaning it will
++     * become the Command located at that index in the ArrayList. This will shift the Command previously located at
++     * that index as well as any located at greater indices, right one index ({@code size()+1}).
++     *
++     * @param  command
++     *         The Command to add
++     * @param  index
++     *         The index to add the Command at (must follow the specifications {@code 0<=index<=size()})
++     *
++     * @throws java.lang.ArrayIndexOutOfBoundsException
++     *         If {@code index < 0} or {@code index > size()}
++     * @throws java.lang.IllegalArgumentException
++     *         If the Command provided has a name or alias that has already been registered to an index
++     */
++    void addSlashCommand(SlashCommand command, int index);
++
+     /**
+      * Removes a single {@link com.jagrosh.jdautilities.command.Command Command} from this CommandClient's
+      * registered Commands at the index linked to the provided name/alias.
+diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/CommandClientBuilder.java b/command/src/main/java/com/jagrosh/jdautilities/command/CommandClientBuilder.java
+index 6d0e434..1defeb2 100644
+--- a/command/src/main/java/com/jagrosh/jdautilities/command/CommandClientBuilder.java
++++ b/command/src/main/java/com/jagrosh/jdautilities/command/CommandClientBuilder.java
+@@ -54,6 +54,7 @@ public class CommandClientBuilder
+     private String carbonKey;
+     private String botsKey;
+     private final LinkedList<Command> commands = new LinkedList<>();
++    private final LinkedList<SlashCommand> slashCommands = new LinkedList<>();
+     private CommandListener listener;
+     private boolean useHelp = true;
+     private boolean shutdownAutomatically = true;
+@@ -75,7 +76,7 @@ public class CommandClientBuilder
+     public CommandClient build()
+     {
+         CommandClient client = new CommandClientImpl(ownerId, coOwnerIds, prefix, altprefix, prefixes, prefixFunction, commandPreProcessFunction, activity, status, serverInvite,
+-                                                     success, warning, error, carbonKey, botsKey, new ArrayList<>(commands), useHelp,
++                                                     success, warning, error, carbonKey, botsKey, new ArrayList<>(commands), new ArrayList<>(slashCommands), useHelp,
+                                                      shutdownAutomatically, helpConsumer, helpWord, executor, linkedCacheSize, compiler, manager);
+         if(listener!=null)
+             client.setListener(listener);
+@@ -346,6 +347,38 @@ public class CommandClientBuilder
+         return this;
+     }
+ 
++    /**
++     * Adds a {@link com.jagrosh.jdautilities.command.SlashCommand SlashCommand} and registers it to the
++     * {@link com.jagrosh.jdautilities.command.impl.CommandClientImpl CommandClientImpl} for this session.
++     *
++     * @param  command
++     *         The SlashCommand to add
++     *
++     * @return This builder
++     */
++    public CommandClientBuilder addSlashCommand(SlashCommand command)
++    {
++        slashCommands.add(command);
++        return this;
++    }
++
++    /**
++     * Adds and registers multiple {@link com.jagrosh.jdautilities.command.SlashCommand SlashCommand}s to the
++     * {@link com.jagrosh.jdautilities.command.impl.CommandClientImpl CommandClientImpl} for this session.
++     * <br>This is the same as calling {@link com.jagrosh.jdautilities.command.CommandClientBuilder#addSlashCommand(SlashCommand)} multiple times.
++     *
++     * @param  commands
++     *         The Commands to add
++     *
++     * @return This builder
++     */
++    public CommandClientBuilder addSlashCommands(SlashCommand... commands)
++    {
++        for(SlashCommand command: commands)
++            this.addSlashCommand(command);
++        return this;
++    }
++
+     /**
+      * Adds an annotated command module to the
+      * {@link com.jagrosh.jdautilities.command.impl.CommandClientImpl CommandClientImpl} for this session.
+diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
+new file mode 100644
+index 0000000..0abf860
+--- /dev/null
++++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
+@@ -0,0 +1,900 @@
++/*
++ * Copyright 2016-2018 John Grosh (jagrosh) & Kaidan Gustave (TheMonitorLizard)
++ *
++ * Licensed under the Apache License, Version 2.0 (the "License");
++ * you may not use this file except in compliance with the License.
++ * You may obtain a copy of the License at
++ *
++ *     http://www.apache.org/licenses/LICENSE-2.0
++ *
++ * Unless required by applicable law or agreed to in writing, software
++ * distributed under the License is distributed on an "AS IS" BASIS,
++ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
++ * See the License for the specific language governing permissions and
++ * limitations under the License.
++ */
++package com.jagrosh.jdautilities.command;
++
++import net.dv8tion.jda.api.Permission;
++import net.dv8tion.jda.api.entities.ChannelType;
++import net.dv8tion.jda.api.entities.GuildVoiceState;
++import net.dv8tion.jda.api.entities.Member;
++import net.dv8tion.jda.api.entities.TextChannel;
++import net.dv8tion.jda.api.entities.VoiceChannel;
++import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
++import net.dv8tion.jda.api.interactions.commands.build.OptionData;
++
++import java.util.ArrayList;
++import java.util.List;
++import java.util.Objects;
++import java.util.function.Predicate;
++
++/**
++ * <h1><b>Slash Commands In JDA-Chewtils</b></h1>
++ * 
++ * <p>This intends to mimic the {@link Command command} with minimal breaking changes,
++ * to make migration easy and smooth.</p>
++ * <p>Breaking changes are documented here: https://github.</p>
++ * {@link SlashCommand#execute(SlashCommandEvent) #execute(CommandEvent)} body:
++ * 
++ * <pre><code> public class ExampleCmd extends Command {
++ *      
++ *      public ExampleCmd() {
++ *          this.name = "example";
++ *          this.help = "gives an example of commands do";
++ *      }
++ *      
++ *      {@literal @Override}
++ *      protected void execute(SlashCommandEvent event) {
++ *          event.reply("Hey look! This would be the bot's reply if this was a command!").queue();
++ *      }
++ *      
++ * }</code></pre>
++ * 
++ * Execution is with the provision of the SlashCommandEvent is performed in two steps:
++ * <ul>
++ *     <li>{@link SlashCommand#run(SlashCommandEvent, CommandClient) run} - The command runs
++ *     through a series of conditionals, automatically terminating the command instance if one is not met, 
++ *     and possibly providing an error response.</li>
++ *     
++ *     <li>{@link SlashCommand#execute(SlashCommandEvent) execute} - The command,
++ *     now being cleared to run, executes and performs whatever lies in the abstract body method.</li>
++ * </ul>
++ * 
++ * @author John Grosh (jagrosh)
++ */
++public abstract class SlashCommand
++{
++    /**
++     * The name of the command. This is what appears in the clients when they type "/"
++     */
++    protected String name = "null";
++
++    /**
++     * A small help String that summarizes the function of the command, used in the Discord description.
++     */
++    protected String help = "no help available";
++
++    /**
++     * The {@link com.jagrosh.jdautilities.command.SlashCommand.Category Category} of the command.
++     * <br>This can perform any other checks not completed by the default conditional fields.
++     */
++    protected Category category = null;
++
++    /**
++     * {@code true} if the command may only be used in a specified {@link net.dv8tion.jda.api.entities.Guild Guild},
++     * {@code false} if it may be used globally.
++     * <br>Default {@code false}.
++     */
++    protected boolean guildOnly = false;
++
++    /**
++     * The ID of the server you want guildOnly tied to.
++     * This means the slash command will only work and show up in the specified Guild.
++     * If this is null, guildOnly will still be processed, however an ephemeral message will be sent telling them to move.
++     */
++    protected String guildId = null;
++
++    /**
++     * A String name of a role required to use this command.
++     */
++    protected String requiredRole = null;
++
++    /**
++     * {@code true} if the command may only be used by a User with an ID matching the
++     * Owners or any of the CoOwners.
++     * <br>Default {@code false}.
++     */
++    protected boolean ownerCommand = false;
++
++    /**
++     * An {@code int} number of seconds users must wait before using this command again.
++     */
++    protected int cooldown = 0;
++
++    /**
++     * Any {@link net.dv8tion.jda.api.Permission Permission}s a Member must have to use this command.
++     * <br>These are only checked in a {@link net.dv8tion.jda.api.entities.Guild Guild} environment.
++     */
++    protected Permission[] userPermissions = new Permission[0];
++
++    /**
++     * Any {@link net.dv8tion.jda.api.Permission Permission}s the bot must have to use a command.
++     * <br>These are only checked in a {@link net.dv8tion.jda.api.entities.Guild Guild} environment.
++     */
++    protected Permission[] botPermissions = new Permission[0];
++
++    /**
++     * The child commands of the command. These are used in the format {@code [prefix]<parent name>
++     * <child name>}.
++     */
++    protected SlashCommand[] children = new SlashCommand[0];
++
++    /**
++     * {@code true} if this command checks a channel topic for topic-tags.
++     * <br>This means that putting {@code {-commandname}}, {@code {-command category}}, {@code {-all}} in a channel topic
++     * will cause this command to terminate.
++     * <br>Default {@code true}.
++     */
++    protected boolean usesTopicTags = true;
++
++    /**
++     * The {@link com.jagrosh.jdautilities.command.SlashCommand.CooldownScope CooldownScope}
++     * of the command. This defines how far of a scope cooldowns have.
++     * <br>Default {@link com.jagrosh.jdautilities.command.SlashCommand.CooldownScope#USER CooldownScope.USER}.
++     */
++    protected CooldownScope cooldownScope = CooldownScope.USER;
++
++    /**
++     * The permission message used when the bot does not have the requires permission.
++     * Requires 3 "%s", first is user mention, second is the permission needed, third is type, e.g. Guild.
++     */
++    protected String botMissingPermMessage = "%s I need the %s permission in this %s!";
++
++    /**
++     * The permission message used when the user does not have the requires permission.
++     * Requires 3 "%s", first is user mention, second is the permission needed, third is type, e.g. Guild.
++     */
++    protected String userMissingPermMessage = "%s You must have the %s permission in this %s to use that!";
++
++    /**
++     * An array list of OptionData.
++     *
++     * This is to specify different options for arguments and the stuff.
++     *
++     * For example, to add an argument for "input", you can do this:<br>
++     * <pre><code> OptionData data = new OptionData(OptionType.STRING, "input", "The input for the command").setRequired(true);
++     *     List OptionData dataList = new ArrayList();
++     *     dataList.add(data);
++     *     this.options = dataList;</code></pre>
++     */
++    protected List<OptionData> options = new ArrayList<>();
++
++    /**
++     * The command client to be retrieved if needed.
++     */
++    protected CommandClient client;
++    
++    /**
++     * The main body method of a {@link SlashCommand Command}.
++     * <br>This is the "response" for a successful 
++     * {@link SlashCommand#run(SlashCommandEvent, CommandClient) #run(CommandEvent)}.
++     * 
++     * @param  event
++     *         The {@link SlashCommandEvent SlashCommandEvent} that
++     *         triggered this Command
++     */
++    protected abstract void execute(SlashCommandEvent event);
++    
++    /**
++     * Runs checks for the {@link SlashCommand SlashCommand} with the
++     * given {@link SlashCommandEvent SlashCommandEvent} that called it.
++     * <br>Will terminate, and possibly respond with a failure message, if any checks fail.
++     * 
++     * @param  event
++     *         The SlashCommandEvent that triggered this Command
++     * @param  client
++     *         The CommandClient for checks and stuff
++     */
++    public final void run(SlashCommandEvent event, CommandClient client)
++    {
++        // set the client
++        this.client = client;
++
++        // owner check
++        if(ownerCommand && !(isOwner(event, client)))
++        {
++            terminate(event,null, client);
++            return;
++        }
++
++        // category check
++        if(category!=null && !category.test(event))
++        {
++            terminate(event, category.getFailureResponse(), client);
++            return;
++        }
++
++        // is allowed check
++        if((event.getChannelType() == ChannelType.TEXT) && !isAllowed(event.getTextChannel()))
++        {
++            terminate(event, "That command cannot be used in this channel!", client);
++            return;
++        }
++        
++        // required role check
++        if(requiredRole!=null)
++            if(!(event.getChannelType() == ChannelType.TEXT) || event.getMember().getRoles().stream().noneMatch(r -> r.getName().equalsIgnoreCase(requiredRole)))
++            {
++                terminate(event, client.getError()+" You must have a role called `"+requiredRole+"` to use that!", client);
++                return;
++            }
++        
++        // availability check
++        if(event.getChannelType()==ChannelType.TEXT)
++        {
++            //user perms
++            for(Permission p: userPermissions)
++            {
++                if(p.isChannel())
++                {
++                    if(!event.getMember().hasPermission(event.getTextChannel(), p))
++                    {
++                        terminate(event, String.format(userMissingPermMessage, client.getError(), p.getName(), "channel"), client);
++                        return;
++                    }
++                }
++                else
++                {
++                    if(!event.getMember().hasPermission(p))
++                    {
++                        terminate(event, String.format(userMissingPermMessage, client.getError(), p.getName(), "server"), client);
++                        return;
++                    }
++                }
++            }
++
++            // bot perms
++            for(Permission p: botPermissions)
++            {
++                Member selfMember = event.getGuild() == null ? null : event.getGuild().getSelfMember();
++                if(p.isChannel())
++                {
++                    if(p.name().startsWith("VOICE"))
++                    {
++                        GuildVoiceState gvc = event.getMember().getVoiceState();
++                        VoiceChannel vc = gvc == null ? null : gvc.getChannel();
++                        if(vc==null)
++                        {
++                            terminate(event, client.getError()+" You must be in a voice channel to use that!", client);
++                            return;
++                        }
++                        else if(!selfMember.hasPermission(vc, p))
++                        {
++                            terminate(event, String.format(botMissingPermMessage, client.getError(), p.getName(), "voice channel"), client);
++                            return;
++                        }
++                    }
++                    else
++                    {
++                        if(!selfMember.hasPermission(event.getTextChannel(), p))
++                        {
++                            terminate(event, String.format(botMissingPermMessage, client.getError(), p.getName(), "channel"), client);
++                            return;
++                        }
++                    }
++                }
++                else
++                {
++                    if(!selfMember.hasPermission(p))
++                    {
++                        terminate(event, String.format(botMissingPermMessage, client.getError(), p.getName(), "server"), client);
++                        return;
++                    }
++                }
++            }
++        }
++        else if(guildOnly)
++        {
++            terminate(event, client.getError()+" This command cannot be used in direct messages", client);
++            return;
++        }
++        
++        // cooldown check, ignoring owner
++        if(cooldown>0 && !(isOwner(event, client)))
++        {
++            String key = getCooldownKey(event);
++            int remaining = client.getRemainingCooldown(key);
++            if(remaining>0)
++            {
++                terminate(event, getCooldownError(event, remaining, client), client);
++                return;
++            }
++            else client.applyCooldown(key, cooldown);
++        }
++        
++        // run
++        try {
++            execute(event);
++        } catch(Throwable t) {
++            if(client.getListener() != null)
++            {
++                //client.getListener().onCommandException(event, this, t);
++                return;
++            }
++            // otherwise we rethrow
++            throw t;
++        }
++
++        // TODO: this
++        //if(client.getListener() != null)
++            //client.getListener().onCompletedCommand(event, this);
++    }
++
++    /**
++     * Tests whether or not the {@link net.dv8tion.jda.api.entities.User User} who triggered this
++     * event is an owner of the bot.
++     *
++     * @param event the event that triggered the command
++     * @param client the command client for checking stuff
++     * @return {@code true} if the User is the Owner, else {@code false}
++     */
++    public boolean isOwner(SlashCommandEvent event, CommandClient client)
++    {
++        if(event.getUser().getId().equals(client.getOwnerId()))
++            return true;
++        if(client.getCoOwnerIds()==null)
++            return false;
++        for(String id : client.getCoOwnerIds())
++            if(id.equals(event.getUser().getId()))
++                return true;
++        return false;
++    }
++    
++    /**
++     * Checks if the given input represents this Command
++     * 
++     * @param  input
++     *         The input to check
++     * 
++     * @return {@code true} if the input is the name or an alias of the Command
++     */
++    public boolean isCommandFor(String input)
++    {
++        return name.equalsIgnoreCase(input);
++    }
++
++    /**
++     * Checks whether a command is allowed in a {@link TextChannel TextChannel}
++     * by searching the channel topic for topic tags relating to the command.
++     *
++     * <p>{-{@link SlashCommand#name name}},
++     * {-{@link SlashCommand.Category category name}}, or {-{@code all}}
++     * are valid examples of ways that this method would return {@code false} if placed in a channel topic.
++     *
++     * <p><b>NOTE:</b>Topic tags are <b>case sensitive</b> and proper usage must be in lower case!
++     * <br>Also note that setting {@link SlashCommand#usesTopicTags usesTopicTags}
++     * to {@code false} will cause this method to always return {@code true}, as the feature would not be applicable
++     * in the first place.
++     *
++     * @param  channel
++     *         The TextChannel to test.
++     *
++     * @return {@code true} if the channel topic doesn't specify any topic-tags that would cause this command
++     *         to be cancelled, or if {@code usesTopicTags} has been set to {@code false}.
++     */
++    public boolean isAllowed(TextChannel channel)
++    {
++        if(!usesTopicTags)
++            return true;
++        if(channel==null)
++            return true;
++        String topic = channel.getTopic();
++        if(topic==null || topic.isEmpty())
++            return true;
++        topic = topic.toLowerCase();
++        String lowerName = name.toLowerCase();
++        if(topic.contains("{"+lowerName+"}"))
++            return true;
++        if(topic.contains("{-"+lowerName+"}"))
++            return false;
++        String lowerCat = category==null ? null : category.getName().toLowerCase();
++        if(lowerCat!=null)
++        {
++            if(topic.contains("{"+lowerCat+"}"))
++                return true;
++            if(topic.contains("{-"+lowerCat+"}"))
++                return false;
++        }
++        return !topic.contains("{-all}");
++    }
++
++    /**
++     * Gets the {@link SlashCommand#name Command.name} for the Command.
++     *
++     * @return The name for the Command
++     */
++    public String getName()
++    {
++        return name;
++    }
++
++    /**
++     * Gets the {@link SlashCommand#help Command.help} for the Command.
++     *
++     * @return The help for the Command
++     */
++    public String getHelp()
++    {
++        return help;
++    }
++
++    /**
++     * Gets the CommandClient.
++     *
++     * @return the CommandClient.
++     */
++    public CommandClient getClient()
++    {
++        return client;
++    }
++
++    /**
++     * Gets the {@link SlashCommand#category Command.category} for the Command.
++     *
++     * @return The category for the Command
++     */
++    public Category getCategory()
++    {
++        return category;
++    }
++
++    /**
++     * Checks if this Command can only be used in a {@link net.dv8tion.jda.api.entities.Guild Guild}.
++     *
++     * @return {@code true} if this Command can only be used in a Guild, else {@code false} if it can
++     *         be used outside of one
++     */
++    public boolean isGuildOnly()
++    {
++        return guildOnly;
++    }
++
++    /**
++     * Gets the associated Guild ID for Guild Only command.
++     *
++     * @return the ID for the specific Guild
++     */
++    public String getGuildId()
++    {
++        return guildId;
++    }
++
++    /**
++     * Gets the options associated with this command.
++     *
++     * @return the OptionData array for options
++     */
++    public List<OptionData> getOptions()
++    {
++        return options;
++    }
++
++    /**
++     * Gets the {@link SlashCommand#requiredRole Command.requiredRole} for the Command.
++     *
++     * @return The requiredRole for the Command
++     */
++    public String getRequiredRole()
++    {
++        return requiredRole;
++    }
++
++    /**
++     * Gets the {@link SlashCommand#cooldown Command.cooldown} for the Command.
++     *
++     * @return The cooldown for the Command
++     */
++    public int getCooldown()
++    {
++        return cooldown;
++    }
++
++    /**
++     * Gets the {@link SlashCommand#userPermissions Command.userPermissions} for the Command.
++     *
++     * @return The userPermissions for the Command
++     */
++    public Permission[] getUserPermissions()
++    {
++        return userPermissions;
++    }
++
++    /**
++     * Gets the {@link SlashCommand#botPermissions Command.botPermissions} for the Command.
++     *
++     * @return The botPermissions for the Command
++     */
++    public Permission[] getBotPermissions()
++    {
++        return botPermissions;
++    }
++
++    /**
++     * Gets the {@link SlashCommand#children Command.children} for the Command.
++     *
++     * @return The children for the Command
++     */
++    public SlashCommand[] getChildren()
++    {
++        return children;
++    }
++
++    /**
++     * Checks whether or not this command is an owner only Command.
++     * 
++     * @return {@code true} if the command is an owner command, otherwise {@code false} if it is not
++     */
++    public boolean isOwnerCommand()
++    {
++        return ownerCommand;
++    }
++
++    private void terminate(SlashCommandEvent event, String message, CommandClient client)
++    {
++        if(message!=null)
++            event.reply(message).setEphemeral(true).queue();
++        /* To-Do I guess
++        if(client.getListener()!=null)
++            client.getListener().onTerminatedCommand(event, this);
++         */
++    }
++
++    /**
++     * Gets the proper cooldown key for this Command under the provided
++     * {@link CommandEvent CommandEvent}.
++     *
++     * @param  event
++     *         The CommandEvent to generate the cooldown for.
++     *
++     * @return A String key to use when applying a cooldown.
++     */
++    public String getCooldownKey(SlashCommandEvent event)
++    {
++        switch (cooldownScope)
++        {
++            case USER:         return cooldownScope.genKey(name,event.getUser().getIdLong());
++            case USER_GUILD:   return event.getGuild()!=null ? cooldownScope.genKey(name,event.getUser().getIdLong(),event.getGuild().getIdLong()) :
++                    CooldownScope.USER_CHANNEL.genKey(name,event.getUser().getIdLong(), event.getChannel().getIdLong());
++            case USER_CHANNEL: return cooldownScope.genKey(name,event.getUser().getIdLong(),event.getChannel().getIdLong());
++            case GUILD:        return event.getGuild()!=null ? cooldownScope.genKey(name,event.getGuild().getIdLong()) :
++                    CooldownScope.CHANNEL.genKey(name,event.getChannel().getIdLong());
++            case CHANNEL:      return cooldownScope.genKey(name,event.getChannel().getIdLong());
++            case SHARD:
++                event.getJDA().getShardInfo();
++                return cooldownScope.genKey(name, event.getJDA().getShardInfo().getShardId());
++            case USER_SHARD:
++                event.getJDA().getShardInfo();
++                return cooldownScope.genKey(name,event.getUser().getIdLong(),event.getJDA().getShardInfo().getShardId());
++            case GLOBAL:       return cooldownScope.genKey(name, 0);
++            default:           return "";
++        }
++    }
++
++    /**
++     * Gets an error message for this Command under the provided
++     * {@link CommandEvent CommanEvent}.
++     *
++     * @param  event
++     *         The CommandEvent to generate the error message for.
++     * @param  remaining
++     *         The remaining number of seconds a command is on cooldown for.
++     * @param client
++     *         The CommandClient for checking stuff
++     *
++     * @return A String error message for this command if {@code remaining > 0},
++     *         else {@code null}.
++     */
++    public String getCooldownError(SlashCommandEvent event, int remaining, CommandClient client)
++    {
++        if(remaining<=0)
++            return null;
++        String front = client.getWarning()+" That command is on cooldown for "+remaining+" more seconds";
++        if(cooldownScope.equals(CooldownScope.USER))
++            return front+"!";
++        else if(cooldownScope.equals(CooldownScope.USER_GUILD) && event.getGuild()==null)
++            return front+" "+ CooldownScope.USER_CHANNEL.errorSpecification+"!";
++        else if(cooldownScope.equals(CooldownScope.GUILD) && event.getGuild()==null)
++            return front+" "+ CooldownScope.CHANNEL.errorSpecification+"!";
++        else
++            return front+" "+cooldownScope.errorSpecification+"!";
++    }
++
++    /**
++     * To be used in {@link SlashCommand Command}s as a means of
++     * organizing commands into "Categories" as well as terminate command usage when the calling 
++     * {@link CommandEvent CommandEvent} doesn't meet
++     * certain requirements.
++     * 
++     * @author John Grosh (jagrosh)
++     */
++    public static class Category
++    {
++        private final String name;
++        private final String failResponse;
++        private final Predicate<SlashCommandEvent> predicate;
++        
++        /**
++         * A Command Category containing a name.
++         * 
++         * @param  name
++         *         The name of the Category
++         */
++        public Category(String name)
++        {
++            this.name = name;
++            this.failResponse = null;
++            this.predicate = null;
++        }
++        
++        /**
++         * A Command Category containing a name and a {@link Predicate}.
++         * 
++         * <p>The command will be terminated if
++         * {@link SlashCommand.Category#test(SlashCommandEvent)}
++         * returns {@code false}.
++         * 
++         * @param  name 
++         *         The name of the Category
++         * @param  predicate
++         *         The Category predicate to test
++         */
++        public Category(String name, Predicate<SlashCommandEvent> predicate)
++        {
++            this.name = name;
++            this.failResponse = null;
++            this.predicate = predicate;
++        }
++        
++        /**
++         * A Command Category containing a name, a {@link Predicate},
++         * and a failure response.
++         * 
++         * <p>The command will be terminated if
++         * {@link SlashCommand.Category#test(SlashCommandEvent)}
++         * returns {@code false}, and the failure response will be sent.
++         * 
++         * @param  name 
++         *         The name of the Category
++         * @param  failResponse
++         *         The response if the test fails
++         * @param  predicate
++         *         The Category predicate to test
++         */
++        public Category(String name, String failResponse, Predicate<SlashCommandEvent> predicate)
++        {
++            this.name = name;
++            this.failResponse = failResponse;
++            this.predicate = predicate;
++        }
++        
++        /**
++         * Gets the name of the Category.
++         * 
++         * @return The name of the Category
++         */
++        public String getName()
++        {
++            return name;
++        }
++        
++        /**
++         * Gets the failure response of the Category.
++         * 
++         * @return The failure response of the Category
++         */
++        public String getFailureResponse()
++        {
++            return failResponse;
++        }
++        
++        /**
++         * Runs a test of the provided {@link Predicate}.
++         * 
++         * @param  event
++         *         The {@link CommandEvent CommandEvent}
++         *         that was called when this method is invoked
++         *         
++         * @return {@code true} if the Predicate was not set, was set as null, or was 
++         *         tested and returned true, otherwise returns {@code false}
++         */
++        public boolean test(SlashCommandEvent event)
++        {
++            return predicate==null || predicate.test(event);
++        }
++
++        @Override
++        public boolean equals(Object obj)
++        {
++            if(!(obj instanceof Category))
++                return false;
++            Category other = (Category)obj;
++            return Objects.equals(name, other.name) && Objects.equals(predicate, other.predicate) && Objects.equals(failResponse, other.failResponse);
++        }
++
++        @Override
++        public int hashCode()
++        {
++            int hash = 7;
++            hash = 17 * hash + Objects.hashCode(this.name);
++            hash = 17 * hash + Objects.hashCode(this.failResponse);
++            hash = 17 * hash + Objects.hashCode(this.predicate);
++            return hash;
++        }
++    }
++
++    /**
++     * A series of {@link Enum Enum}s used for defining the scope size for a
++     * {@link SlashCommand Command}'s cooldown.
++     *
++     * <p>The purpose for these values is to allow easy, refined, and generally convenient keys
++     * for cooldown scopes, allowing a command to remain on cooldown for more than just the user
++     * calling it, with no unnecessary abstraction or developer input.
++     *
++     * Cooldown keys are generated via {@link SlashCommand#getCooldownKey(SlashCommandEvent)
++     * Command#getCooldownKey(CommandEvent)} using 1-2 Snowflake ID's corresponding to the name
++     * (IE: {@code USER_CHANNEL} uses the ID's of the User and the Channel from the CommandEvent).
++     *
++     * <p>However, the issue with generalizing and generating like this is that the command may
++     * be called in a non-guild environment, causing errors internally.
++     * <br>To prevent this, all of the values that contain "{@code GUILD}" in their name default
++     * to their "{@code CHANNEL}" counterparts when commands using them are called outside of a
++     * {@link net.dv8tion.jda.api.entities.Guild Guild} environment.
++     * <ul>
++     *     <li>{@link SlashCommand.CooldownScope#GUILD GUILD} defaults to
++     *     {@link SlashCommand.CooldownScope#CHANNEL CHANNEL}.</li>
++     *     <li>{@link SlashCommand.CooldownScope#USER_GUILD USER_GUILD} defaults to
++     *     {@link SlashCommand.CooldownScope#USER_CHANNEL USER_CHANNEL}.</li>
++     * </ul>
++     *
++     * These are effective across a single instance of JDA, and not multiple
++     * ones, save when multiple shards run on a single JVM and under a
++     * {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager}.
++     * <br>There is no shard magic, and no guarantees for a 100% "global"
++     * cooldown, unless all shards of the bot run under the same ShardManager,
++     * and/or via some external system unrelated to JDA-Utilities.
++     *
++     * @since  1.3
++     * @author Kaidan Gustave
++     *
++     * @see    SlashCommand#cooldownScope Command.cooldownScope
++     */
++    public enum CooldownScope
++    {
++        /**
++         * Applies the cooldown to the calling {@link net.dv8tion.jda.api.entities.User User} across all
++         * locations on this instance (IE: TextChannels, PrivateChannels, etc).
++         *
++         * <p>The key for this is generated in the format
++         * <ul>
++         *     {@code <command-name>|U:<userID>}
++         * </ul>
++         */
++        USER("U:%d",""),
++
++        /**
++         * Applies the cooldown to the {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel} the
++         * command is called in.
++         *
++         * <p>The key for this is generated in the format
++         * <ul>
++         *     {@code <command-name>|C:<channelID>}
++         * </ul>
++         */
++        CHANNEL("C:%d","in this channel"),
++
++        /**
++         * Applies the cooldown to the calling {@link net.dv8tion.jda.api.entities.User User} local to the
++         * {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel} the command is called in.
++         *
++         * <p>The key for this is generated in the format
++         * <ul>
++         *     {@code <command-name>|U:<userID>|C:<channelID>}
++         * </ul>
++         */
++        USER_CHANNEL("U:%d|C:%d", "in this channel"),
++
++        /**
++         * Applies the cooldown to the {@link net.dv8tion.jda.api.entities.Guild Guild} the command is called in.
++         *
++         * <p>The key for this is generated in the format
++         * <ul>
++         *     {@code <command-name>|G:<guildID>}
++         * </ul>
++         *
++         * <p><b>NOTE:</b> This will automatically default back to {@link SlashCommand.CooldownScope#CHANNEL CooldownScope.CHANNEL}
++         * when called in a private channel.  This is done in order to prevent internal
++         * {@link NullPointerException NullPointerException}s from being thrown while generating cooldown keys!
++         */
++        GUILD("G:%d", "in this server"),
++
++        /**
++         * Applies the cooldown to the calling {@link net.dv8tion.jda.api.entities.User User} local to the
++         * {@link net.dv8tion.jda.api.entities.Guild Guild} the command is called in.
++         *
++         * <p>The key for this is generated in the format
++         * <ul>
++         *     {@code <command-name>|U:<userID>|G:<guildID>}
++         * </ul>
++         *
++         * <p><b>NOTE:</b> This will automatically default back to {@link SlashCommand.CooldownScope#CHANNEL CooldownScope.CHANNEL}
++         * when called in a private channel. This is done in order to prevent internal
++         * {@link NullPointerException NullPointerException}s from being thrown while generating cooldown keys!
++         */
++        USER_GUILD("U:%d|G:%d", "in this server"),
++
++        /**
++         * Applies the cooldown to the calling Shard the command is called on.
++         *
++         * <p>The key for this is generated in the format
++         * <ul>
++         *     {@code <command-name>|S:<shardID>}
++         * </ul>
++         *
++         * <p><b>NOTE:</b> This will automatically default back to {@link SlashCommand.CooldownScope#GLOBAL CooldownScope.GLOBAL}
++         * when {@link net.dv8tion.jda.api.JDA#getShardInfo() JDA#getShardInfo()} returns {@code null}.
++         * This is done in order to prevent internal {@link NullPointerException NullPointerException}s
++         * from being thrown while generating cooldown keys!
++         */
++        SHARD("S:%d", "on this shard"),
++
++        /**
++         * Applies the cooldown to the calling {@link net.dv8tion.jda.api.entities.User User} on the Shard
++         * the command is called on.
++         *
++         * <p>The key for this is generated in the format
++         * <ul>
++         *     {@code <command-name>|U:<userID>|S:<shardID>}
++         * </ul>
++         *
++         * <p><b>NOTE:</b> This will automatically default back to {@link SlashCommand.CooldownScope#USER CooldownScope.USER}
++         * when {@link net.dv8tion.jda.api.JDA#getShardInfo() JDA#getShardInfo()} returns {@code null}.
++         * This is done in order to prevent internal {@link NullPointerException NullPointerException}s
++         * from being thrown while generating cooldown keys!
++         */
++        USER_SHARD("U:%d|S:%d", "on this shard"),
++
++        /**
++         * Applies this cooldown globally.
++         *
++         * <p>As this implies: the command will be unusable on the instance of JDA in all types of
++         * {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}s until the cooldown has ended.
++         *
++         * <p>The key for this is {@code <command-name>|globally}
++         */
++        GLOBAL("Global", "globally");
++
++        private final String format;
++        final String errorSpecification;
++
++        CooldownScope(String format, String errorSpecification)
++        {
++            this.format = format;
++            this.errorSpecification = errorSpecification;
++        }
++
++        String genKey(String name, long id)
++        {
++            return genKey(name, id, -1);
++        }
++
++        String genKey(String name, long idOne, long idTwo)
++        {
++            if(this.equals(GLOBAL))
++                return name+"|"+format;
++            else if(idTwo==-1)
++                return name+"|"+String.format(format,idOne);
++            else return name+"|"+String.format(format,idOne,idTwo);
++        }
++    }
++}
+diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+index 5a5e7d2..b981dc6 100644
+--- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
++++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
+@@ -28,9 +28,12 @@ import net.dv8tion.jda.api.events.ReadyEvent;
+ import net.dv8tion.jda.api.events.ShutdownEvent;
+ import net.dv8tion.jda.api.events.guild.GuildJoinEvent;
+ import net.dv8tion.jda.api.events.guild.GuildLeaveEvent;
++import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
+ import net.dv8tion.jda.api.events.message.MessageReceivedEvent;
+ import net.dv8tion.jda.api.events.message.guild.GuildMessageDeleteEvent;
+ import net.dv8tion.jda.api.hooks.EventListener;
++import net.dv8tion.jda.api.interactions.commands.build.CommandData;
++import net.dv8tion.jda.api.interactions.commands.build.OptionData;
+ import net.dv8tion.jda.internal.utils.Checks;
+ import okhttp3.*;
+ import org.json.JSONObject;
+@@ -78,7 +81,10 @@ public class CommandClientImpl implements CommandClient, EventListener
+     private final Function<MessageReceivedEvent, Boolean> commandPreProcessFunction;
+     private final String serverInvite;
+     private final HashMap<String, Integer> commandIndex;
++    private final HashMap<String, Integer> slashCommandIndex;
+     private final ArrayList<Command> commands;
++    private final ArrayList<SlashCommand> slashCommands;
++    private final ArrayList<String> slashCommandIds;
+     private final String success;
+     private final String warning;
+     private final String error;
+@@ -99,7 +105,7 @@ public class CommandClientImpl implements CommandClient, EventListener
+     private int totalGuilds;
+ 
+     public CommandClientImpl(String ownerId, String[] coOwnerIds, String prefix, String altprefix, String[] prefixes, Function<MessageReceivedEvent, String> prefixFunction, Function<MessageReceivedEvent, Boolean> commandPreProcessFunction, Activity activity, OnlineStatus status, String serverInvite,
+-                             String success, String warning, String error, String carbonKey, String botsKey, ArrayList<Command> commands,
++                             String success, String warning, String error, String carbonKey, String botsKey, ArrayList<Command> commands, ArrayList<SlashCommand> slashCommands,
+                              boolean useHelp, boolean shutdownAutomatically, Consumer<CommandEvent> helpConsumer, String helpWord, ScheduledExecutorService executor,
+                              int linkedCacheSize, AnnotatedModuleCompiler compiler, GuildSettingsManager manager)
+     {
+@@ -136,7 +142,10 @@ public class CommandClientImpl implements CommandClient, EventListener
+         this.carbonKey = carbonKey;
+         this.botsKey = botsKey;
+         this.commandIndex = new HashMap<>();
++        this.slashCommandIndex = new HashMap<>();
+         this.commands = new ArrayList<>();
++        this.slashCommands = new ArrayList<>();
++        this.slashCommandIds = new ArrayList<>();
+         this.cooldowns = new HashMap<>();
+         this.uses = new HashMap<>();
+         this.linkMap = linkedCacheSize>0 ? new FixedSizeCache<>(linkedCacheSize) : null;
+@@ -182,6 +191,12 @@ public class CommandClientImpl implements CommandClient, EventListener
+         {
+             addCommand(command);
+         }
++
++        // Load slash commands
++        for(SlashCommand command : slashCommands)
++        {
++            addSlashCommand(command);
++        }
+     }
+ 
+     @Override
+@@ -292,6 +307,35 @@ public class CommandClientImpl implements CommandClient, EventListener
+         commands.add(index,command);
+     }
+ 
++    @Override
++    public void addSlashCommand(SlashCommand command)
++    {
++        addSlashCommand(command, slashCommands.size());
++    }
++
++    @Override
++    public void addSlashCommand(SlashCommand command, int index)
++    {
++        if(index>slashCommands.size() || index<0)
++            throw new ArrayIndexOutOfBoundsException("Index specified is invalid: ["+index+"/"+slashCommands.size()+"]");
++        synchronized(slashCommandIndex)
++        {
++            String name = command.getName().toLowerCase();
++            //check for collision
++            if(slashCommandIndex.containsKey(name))
++                throw new IllegalArgumentException("Command added has a name that has already been indexed: \""+name+"\"!");
++            //shift if not append
++            if(index<slashCommands.size())
++            {
++                slashCommandIndex.entrySet().stream().filter(entry -> entry.getValue()>=index).collect(Collectors.toList())
++                    .forEach(entry -> slashCommandIndex.put(entry.getKey(), entry.getValue()+1));
++            }
++            //add
++            slashCommandIndex.put(name, index);
++        }
++        slashCommands.add(index,command);
++    }
++
+     @Override
+     public void removeCommand(String name)
+     {
+@@ -455,12 +499,21 @@ public class CommandClientImpl implements CommandClient, EventListener
+         executor.shutdown();
+     }
+ 
++    public void removeSlashCommands(JDA jda) {
++        for (String id : slashCommandIds) {
++            jda.deleteCommandById(id).queue();
++        }
++    }
++
+     @Override
+     public void onEvent(GenericEvent event)
+     {
+         if(event instanceof MessageReceivedEvent)
+             onMessageReceived((MessageReceivedEvent)event);
+ 
++        else if(event instanceof SlashCommandEvent)
++            onSlashCommand((SlashCommandEvent)event);
++
+         else if(event instanceof GuildMessageDeleteEvent && usesLinkedDeletion())
+             onMessageDelete((GuildMessageDeleteEvent) event);
+ 
+@@ -476,6 +529,7 @@ public class CommandClientImpl implements CommandClient, EventListener
+             onReady((ReadyEvent)event);
+         else if(event instanceof ShutdownEvent)
+         {
++            removeSlashCommands(event.getJDA());
+             if(shutdownAutomatically)
+                 shutdown();
+         }
+@@ -498,6 +552,27 @@ public class CommandClientImpl implements CommandClient, EventListener
+         if(manager != null)
+             manager.init();
+ 
++        // Upsert slash commands
++        System.out.println("Upserting slash commands");
++        for (SlashCommand command : slashCommands)
++        {
++            System.out.println("Generating CommandData for " + command.getName() + ".");
++            CommandData data = new CommandData(command.getName(), command.getHelp());
++            if (!command.getOptions().isEmpty()) {
++                for (OptionData optionData : command.getOptions()) {
++                    data.addOption(optionData);
++                }
++            }
++
++            if (command.isGuildOnly() && command.getGuildId() != null) {
++                System.out.println("Adding command " + command.getName() + " to server " + command.getGuildId());
++                event.getJDA().getGuildById(command.getGuildId()).upsertCommand(data).queue(command1 -> slashCommandIds.add(command1.getId()));
++            } else {
++                System.out.println("Adding command " + command.getName());
++                event.getJDA().upsertCommand(data).queue(command1 -> slashCommandIds.add(command1.getId()));
++            }
++        }
++
+         sendStats(event.getJDA());
+     }
+ 
+@@ -607,6 +682,29 @@ public class CommandClientImpl implements CommandClient, EventListener
+             listener.onNonCommandMessage(event);
+     }
+ 
++    private void onSlashCommand(SlashCommandEvent event)
++    {
++        final SlashCommand command; // this will be null if it's not a command
++        synchronized(slashCommandIndex)
++        {
++            int i = slashCommandIndex.getOrDefault(event.getName().toLowerCase(), -1);
++            command = i != -1? slashCommands.get(i) : null;
++        }
++
++        if(command != null)
++        {
++            //if(listener != null)
++            //    listener.onCommand(cevent, command);
++            uses.put(command.getName(), uses.getOrDefault(command.getName(), 0) + 1);
++            command.run(event, this);
++            return; // Command is done
++        }
++
++
++        //if(listener != null)
++        //    listener.onNonCommandMessage(event);
++    }
++
+     private void sendStats(JDA jda)
+     {
+         OkHttpClient client = jda.getHttpClient();
+-- 
+2.30.1
+

--- a/JDA-Utilities-Patches/0012-Slash-command-support.patch
+++ b/JDA-Utilities-Patches/0012-Slash-command-support.patch
@@ -1,4 +1,4 @@
-From bc6830c1548f9e8853db4124cc349e8e1c0dffa8 Mon Sep 17 00:00:00 2001
+From 95c69c98e854493e07dc40f7cd3fbe233e36212f Mon Sep 17 00:00:00 2001
 From: Chew <chew@chew.pw>
 Date: Sun, 23 May 2021 17:46:44 -0500
 Subject: [PATCH] Slash command support
@@ -36,6 +36,61 @@ index 0b5d4e2..8d89cce 100644
      }
  
      build {
+diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/Command.java b/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
+index d8186b1..ed2dcf0 100644
+--- a/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
++++ b/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
+@@ -68,12 +68,15 @@ import net.dv8tion.jda.api.entities.VoiceChannel;
+ public abstract class Command
+ {
+     /**
+-     * The name of the command, allows the command to be called the format: {@code [prefix]<command name>}.
++     * The name of the command, allows the command to be called the formats: <br>
++     * Normal Command: {@code [prefix]<command name>}. <br>
++     * Slash Command: {@code /<command name>}
+      */
+     protected String name = "null";
+     
+     /**
+-     * A small help String that summarizes the function of the command, used in the default help builder.
++     * A small help String that summarizes the function of the command, used in the default help builder,
++     * and shown in the client for Slash Commands.
+      */
+     protected String help = "no help available";
+     
+@@ -85,6 +88,8 @@ public abstract class Command
+     
+     /**
+      * An arguments format String for the command, used in the default help builder.
++     * Not supported for SlashCommands.
++     * @see SlashCommand#options
+      */
+     protected String arguments = null;
+     
+@@ -127,6 +132,7 @@ public abstract class Command
+     /**
+      * The aliases of the command, when calling a command these function identically to calling the
+      * {@link com.jagrosh.jdautilities.command.Command#name Command.name}.
++     * This options only works for normal commands, not slash commands.
+      */
+     protected String[] aliases = new String[0];
+     
+@@ -153,6 +159,7 @@ public abstract class Command
+     /**
+      * {@code true} if this command should be hidden from the help.
+      * <br>Default {@code false}
++     * This won't work for Slash Commands, as they will always show up.
+      */
+     protected boolean hidden = false;
+ 
+@@ -692,6 +699,7 @@ public abstract class Command
+         
+         /**
+          * Runs a test of the provided {@link java.util.function.Predicate}.
++         * Does not support SlashCommands.
+          * 
+          * @param  event
+          *         The {@link com.jagrosh.jdautilities.command.CommandEvent CommandEvent}
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/CommandClient.java b/command/src/main/java/com/jagrosh/jdautilities/command/CommandClient.java
 index f8db009..76627dd 100644
 --- a/command/src/main/java/com/jagrosh/jdautilities/command/CommandClient.java
@@ -166,10 +221,10 @@ index 6d0e434..1defeb2 100644
       * {@link com.jagrosh.jdautilities.command.impl.CommandClientImpl CommandClientImpl} for this session.
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
 new file mode 100644
-index 0000000..0abf860
+index 0000000..fa53eae
 --- /dev/null
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
-@@ -0,0 +1,900 @@
+@@ -0,0 +1,390 @@
 +/*
 + * Copyright 2016-2018 John Grosh (jagrosh) & Kaidan Gustave (TheMonitorLizard)
 + *
@@ -191,15 +246,12 @@ index 0000000..0abf860
 +import net.dv8tion.jda.api.entities.ChannelType;
 +import net.dv8tion.jda.api.entities.GuildVoiceState;
 +import net.dv8tion.jda.api.entities.Member;
-+import net.dv8tion.jda.api.entities.TextChannel;
 +import net.dv8tion.jda.api.entities.VoiceChannel;
 +import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
 +import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 +
 +import java.util.ArrayList;
 +import java.util.List;
-+import java.util.Objects;
-+import java.util.function.Predicate;
 +
 +/**
 + * <h1><b>Slash Commands In JDA-Chewtils</b></h1>
@@ -235,30 +287,13 @@ index 0000000..0abf860
 + * 
 + * @author John Grosh (jagrosh)
 + */
-+public abstract class SlashCommand
++public abstract class SlashCommand extends Command
 +{
 +    /**
-+     * The name of the command. This is what appears in the clients when they type "/"
++     * The child commands of the command. These are used in the format {@code /<parent name>
++     * <child name>}.
 +     */
-+    protected String name = "null";
-+
-+    /**
-+     * A small help String that summarizes the function of the command, used in the Discord description.
-+     */
-+    protected String help = "no help available";
-+
-+    /**
-+     * The {@link com.jagrosh.jdautilities.command.SlashCommand.Category Category} of the command.
-+     * <br>This can perform any other checks not completed by the default conditional fields.
-+     */
-+    protected Category category = null;
-+
-+    /**
-+     * {@code true} if the command may only be used in a specified {@link net.dv8tion.jda.api.entities.Guild Guild},
-+     * {@code false} if it may be used globally.
-+     * <br>Default {@code false}.
-+     */
-+    protected boolean guildOnly = false;
++    protected SlashCommand[] children = new SlashCommand[0];
 +
 +    /**
 +     * The ID of the server you want guildOnly tied to.
@@ -266,68 +301,6 @@ index 0000000..0abf860
 +     * If this is null, guildOnly will still be processed, however an ephemeral message will be sent telling them to move.
 +     */
 +    protected String guildId = null;
-+
-+    /**
-+     * A String name of a role required to use this command.
-+     */
-+    protected String requiredRole = null;
-+
-+    /**
-+     * {@code true} if the command may only be used by a User with an ID matching the
-+     * Owners or any of the CoOwners.
-+     * <br>Default {@code false}.
-+     */
-+    protected boolean ownerCommand = false;
-+
-+    /**
-+     * An {@code int} number of seconds users must wait before using this command again.
-+     */
-+    protected int cooldown = 0;
-+
-+    /**
-+     * Any {@link net.dv8tion.jda.api.Permission Permission}s a Member must have to use this command.
-+     * <br>These are only checked in a {@link net.dv8tion.jda.api.entities.Guild Guild} environment.
-+     */
-+    protected Permission[] userPermissions = new Permission[0];
-+
-+    /**
-+     * Any {@link net.dv8tion.jda.api.Permission Permission}s the bot must have to use a command.
-+     * <br>These are only checked in a {@link net.dv8tion.jda.api.entities.Guild Guild} environment.
-+     */
-+    protected Permission[] botPermissions = new Permission[0];
-+
-+    /**
-+     * The child commands of the command. These are used in the format {@code [prefix]<parent name>
-+     * <child name>}.
-+     */
-+    protected SlashCommand[] children = new SlashCommand[0];
-+
-+    /**
-+     * {@code true} if this command checks a channel topic for topic-tags.
-+     * <br>This means that putting {@code {-commandname}}, {@code {-command category}}, {@code {-all}} in a channel topic
-+     * will cause this command to terminate.
-+     * <br>Default {@code true}.
-+     */
-+    protected boolean usesTopicTags = true;
-+
-+    /**
-+     * The {@link com.jagrosh.jdautilities.command.SlashCommand.CooldownScope CooldownScope}
-+     * of the command. This defines how far of a scope cooldowns have.
-+     * <br>Default {@link com.jagrosh.jdautilities.command.SlashCommand.CooldownScope#USER CooldownScope.USER}.
-+     */
-+    protected CooldownScope cooldownScope = CooldownScope.USER;
-+
-+    /**
-+     * The permission message used when the bot does not have the requires permission.
-+     * Requires 3 "%s", first is user mention, second is the permission needed, third is type, e.g. Guild.
-+     */
-+    protected String botMissingPermMessage = "%s I need the %s permission in this %s!";
-+
-+    /**
-+     * The permission message used when the user does not have the requires permission.
-+     * Requires 3 "%s", first is user mention, second is the permission needed, third is type, e.g. Guild.
-+     */
-+    protected String userMissingPermMessage = "%s You must have the %s permission in this %s to use that!";
 +
 +    /**
 +     * An array list of OptionData.
@@ -348,7 +321,7 @@ index 0000000..0abf860
 +    protected CommandClient client;
 +    
 +    /**
-+     * The main body method of a {@link SlashCommand Command}.
++     * The main body method of a {@link SlashCommand SlashCommand}.
 +     * <br>This is the "response" for a successful 
 +     * {@link SlashCommand#run(SlashCommandEvent, CommandClient) #run(CommandEvent)}.
 +     * 
@@ -357,6 +330,22 @@ index 0000000..0abf860
 +     *         triggered this Command
 +     */
 +    protected abstract void execute(SlashCommandEvent event);
++
++    /**
++     * The main body method of a {@link com.jagrosh.jdautilities.command.Command Command}.
++     * <br>This is the "response" for a successful
++     * {@link com.jagrosh.jdautilities.command.Command#run(CommandEvent) #run(CommandEvent)}.
++     * <b>
++     *     Because this is a SlashCommand, this is called, but does nothing.
++     *     You can still override this if you want to have a separate response for normal [prefix][name].
++     * </b>
++     *
++     * @param  event
++     *         The {@link com.jagrosh.jdautilities.command.CommandEvent CommandEvent} that
++     *         triggered this Command
++     */
++    @Override
++    protected void execute(CommandEvent event) {}
 +    
 +    /**
 +     * Runs checks for the {@link SlashCommand SlashCommand} with the
@@ -377,13 +366,6 @@ index 0000000..0abf860
 +        if(ownerCommand && !(isOwner(event, client)))
 +        {
 +            terminate(event,null, client);
-+            return;
-+        }
-+
-+        // category check
-+        if(category!=null && !category.test(event))
-+        {
-+            terminate(event, category.getFailureResponse(), client);
 +            return;
 +        }
 +
@@ -522,84 +504,6 @@ index 0000000..0abf860
 +                return true;
 +        return false;
 +    }
-+    
-+    /**
-+     * Checks if the given input represents this Command
-+     * 
-+     * @param  input
-+     *         The input to check
-+     * 
-+     * @return {@code true} if the input is the name or an alias of the Command
-+     */
-+    public boolean isCommandFor(String input)
-+    {
-+        return name.equalsIgnoreCase(input);
-+    }
-+
-+    /**
-+     * Checks whether a command is allowed in a {@link TextChannel TextChannel}
-+     * by searching the channel topic for topic tags relating to the command.
-+     *
-+     * <p>{-{@link SlashCommand#name name}},
-+     * {-{@link SlashCommand.Category category name}}, or {-{@code all}}
-+     * are valid examples of ways that this method would return {@code false} if placed in a channel topic.
-+     *
-+     * <p><b>NOTE:</b>Topic tags are <b>case sensitive</b> and proper usage must be in lower case!
-+     * <br>Also note that setting {@link SlashCommand#usesTopicTags usesTopicTags}
-+     * to {@code false} will cause this method to always return {@code true}, as the feature would not be applicable
-+     * in the first place.
-+     *
-+     * @param  channel
-+     *         The TextChannel to test.
-+     *
-+     * @return {@code true} if the channel topic doesn't specify any topic-tags that would cause this command
-+     *         to be cancelled, or if {@code usesTopicTags} has been set to {@code false}.
-+     */
-+    public boolean isAllowed(TextChannel channel)
-+    {
-+        if(!usesTopicTags)
-+            return true;
-+        if(channel==null)
-+            return true;
-+        String topic = channel.getTopic();
-+        if(topic==null || topic.isEmpty())
-+            return true;
-+        topic = topic.toLowerCase();
-+        String lowerName = name.toLowerCase();
-+        if(topic.contains("{"+lowerName+"}"))
-+            return true;
-+        if(topic.contains("{-"+lowerName+"}"))
-+            return false;
-+        String lowerCat = category==null ? null : category.getName().toLowerCase();
-+        if(lowerCat!=null)
-+        {
-+            if(topic.contains("{"+lowerCat+"}"))
-+                return true;
-+            if(topic.contains("{-"+lowerCat+"}"))
-+                return false;
-+        }
-+        return !topic.contains("{-all}");
-+    }
-+
-+    /**
-+     * Gets the {@link SlashCommand#name Command.name} for the Command.
-+     *
-+     * @return The name for the Command
-+     */
-+    public String getName()
-+    {
-+        return name;
-+    }
-+
-+    /**
-+     * Gets the {@link SlashCommand#help Command.help} for the Command.
-+     *
-+     * @return The help for the Command
-+     */
-+    public String getHelp()
-+    {
-+        return help;
-+    }
 +
 +    /**
 +     * Gets the CommandClient.
@@ -609,27 +513,6 @@ index 0000000..0abf860
 +    public CommandClient getClient()
 +    {
 +        return client;
-+    }
-+
-+    /**
-+     * Gets the {@link SlashCommand#category Command.category} for the Command.
-+     *
-+     * @return The category for the Command
-+     */
-+    public Category getCategory()
-+    {
-+        return category;
-+    }
-+
-+    /**
-+     * Checks if this Command can only be used in a {@link net.dv8tion.jda.api.entities.Guild Guild}.
-+     *
-+     * @return {@code true} if this Command can only be used in a Guild, else {@code false} if it can
-+     *         be used outside of one
-+     */
-+    public boolean isGuildOnly()
-+    {
-+        return guildOnly;
 +    }
 +
 +    /**
@@ -653,46 +536,6 @@ index 0000000..0abf860
 +    }
 +
 +    /**
-+     * Gets the {@link SlashCommand#requiredRole Command.requiredRole} for the Command.
-+     *
-+     * @return The requiredRole for the Command
-+     */
-+    public String getRequiredRole()
-+    {
-+        return requiredRole;
-+    }
-+
-+    /**
-+     * Gets the {@link SlashCommand#cooldown Command.cooldown} for the Command.
-+     *
-+     * @return The cooldown for the Command
-+     */
-+    public int getCooldown()
-+    {
-+        return cooldown;
-+    }
-+
-+    /**
-+     * Gets the {@link SlashCommand#userPermissions Command.userPermissions} for the Command.
-+     *
-+     * @return The userPermissions for the Command
-+     */
-+    public Permission[] getUserPermissions()
-+    {
-+        return userPermissions;
-+    }
-+
-+    /**
-+     * Gets the {@link SlashCommand#botPermissions Command.botPermissions} for the Command.
-+     *
-+     * @return The botPermissions for the Command
-+     */
-+    public Permission[] getBotPermissions()
-+    {
-+        return botPermissions;
-+    }
-+
-+    /**
 +     * Gets the {@link SlashCommand#children Command.children} for the Command.
 +     *
 +     * @return The children for the Command
@@ -700,16 +543,6 @@ index 0000000..0abf860
 +    public SlashCommand[] getChildren()
 +    {
 +        return children;
-+    }
-+
-+    /**
-+     * Checks whether or not this command is an owner only Command.
-+     * 
-+     * @return {@code true} if the command is an owner command, otherwise {@code false} if it is not
-+     */
-+    public boolean isOwnerCommand()
-+    {
-+        return ownerCommand;
 +    }
 +
 +    private void terminate(SlashCommandEvent event, String message, CommandClient client)
@@ -724,7 +557,7 @@ index 0000000..0abf860
 +
 +    /**
 +     * Gets the proper cooldown key for this Command under the provided
-+     * {@link CommandEvent CommandEvent}.
++     * {@link SlashCommandEvent SlashCommandEvent}.
 +     *
 +     * @param  event
 +     *         The CommandEvent to generate the cooldown for.
@@ -755,7 +588,7 @@ index 0000000..0abf860
 +
 +    /**
 +     * Gets an error message for this Command under the provided
-+     * {@link CommandEvent CommanEvent}.
++     * {@link SlashCommandEvent SlashCommandEvent}.
 +     *
 +     * @param  event
 +     *         The CommandEvent to generate the error message for.
@@ -780,294 +613,6 @@ index 0000000..0abf860
 +            return front+" "+ CooldownScope.CHANNEL.errorSpecification+"!";
 +        else
 +            return front+" "+cooldownScope.errorSpecification+"!";
-+    }
-+
-+    /**
-+     * To be used in {@link SlashCommand Command}s as a means of
-+     * organizing commands into "Categories" as well as terminate command usage when the calling 
-+     * {@link CommandEvent CommandEvent} doesn't meet
-+     * certain requirements.
-+     * 
-+     * @author John Grosh (jagrosh)
-+     */
-+    public static class Category
-+    {
-+        private final String name;
-+        private final String failResponse;
-+        private final Predicate<SlashCommandEvent> predicate;
-+        
-+        /**
-+         * A Command Category containing a name.
-+         * 
-+         * @param  name
-+         *         The name of the Category
-+         */
-+        public Category(String name)
-+        {
-+            this.name = name;
-+            this.failResponse = null;
-+            this.predicate = null;
-+        }
-+        
-+        /**
-+         * A Command Category containing a name and a {@link Predicate}.
-+         * 
-+         * <p>The command will be terminated if
-+         * {@link SlashCommand.Category#test(SlashCommandEvent)}
-+         * returns {@code false}.
-+         * 
-+         * @param  name 
-+         *         The name of the Category
-+         * @param  predicate
-+         *         The Category predicate to test
-+         */
-+        public Category(String name, Predicate<SlashCommandEvent> predicate)
-+        {
-+            this.name = name;
-+            this.failResponse = null;
-+            this.predicate = predicate;
-+        }
-+        
-+        /**
-+         * A Command Category containing a name, a {@link Predicate},
-+         * and a failure response.
-+         * 
-+         * <p>The command will be terminated if
-+         * {@link SlashCommand.Category#test(SlashCommandEvent)}
-+         * returns {@code false}, and the failure response will be sent.
-+         * 
-+         * @param  name 
-+         *         The name of the Category
-+         * @param  failResponse
-+         *         The response if the test fails
-+         * @param  predicate
-+         *         The Category predicate to test
-+         */
-+        public Category(String name, String failResponse, Predicate<SlashCommandEvent> predicate)
-+        {
-+            this.name = name;
-+            this.failResponse = failResponse;
-+            this.predicate = predicate;
-+        }
-+        
-+        /**
-+         * Gets the name of the Category.
-+         * 
-+         * @return The name of the Category
-+         */
-+        public String getName()
-+        {
-+            return name;
-+        }
-+        
-+        /**
-+         * Gets the failure response of the Category.
-+         * 
-+         * @return The failure response of the Category
-+         */
-+        public String getFailureResponse()
-+        {
-+            return failResponse;
-+        }
-+        
-+        /**
-+         * Runs a test of the provided {@link Predicate}.
-+         * 
-+         * @param  event
-+         *         The {@link CommandEvent CommandEvent}
-+         *         that was called when this method is invoked
-+         *         
-+         * @return {@code true} if the Predicate was not set, was set as null, or was 
-+         *         tested and returned true, otherwise returns {@code false}
-+         */
-+        public boolean test(SlashCommandEvent event)
-+        {
-+            return predicate==null || predicate.test(event);
-+        }
-+
-+        @Override
-+        public boolean equals(Object obj)
-+        {
-+            if(!(obj instanceof Category))
-+                return false;
-+            Category other = (Category)obj;
-+            return Objects.equals(name, other.name) && Objects.equals(predicate, other.predicate) && Objects.equals(failResponse, other.failResponse);
-+        }
-+
-+        @Override
-+        public int hashCode()
-+        {
-+            int hash = 7;
-+            hash = 17 * hash + Objects.hashCode(this.name);
-+            hash = 17 * hash + Objects.hashCode(this.failResponse);
-+            hash = 17 * hash + Objects.hashCode(this.predicate);
-+            return hash;
-+        }
-+    }
-+
-+    /**
-+     * A series of {@link Enum Enum}s used for defining the scope size for a
-+     * {@link SlashCommand Command}'s cooldown.
-+     *
-+     * <p>The purpose for these values is to allow easy, refined, and generally convenient keys
-+     * for cooldown scopes, allowing a command to remain on cooldown for more than just the user
-+     * calling it, with no unnecessary abstraction or developer input.
-+     *
-+     * Cooldown keys are generated via {@link SlashCommand#getCooldownKey(SlashCommandEvent)
-+     * Command#getCooldownKey(CommandEvent)} using 1-2 Snowflake ID's corresponding to the name
-+     * (IE: {@code USER_CHANNEL} uses the ID's of the User and the Channel from the CommandEvent).
-+     *
-+     * <p>However, the issue with generalizing and generating like this is that the command may
-+     * be called in a non-guild environment, causing errors internally.
-+     * <br>To prevent this, all of the values that contain "{@code GUILD}" in their name default
-+     * to their "{@code CHANNEL}" counterparts when commands using them are called outside of a
-+     * {@link net.dv8tion.jda.api.entities.Guild Guild} environment.
-+     * <ul>
-+     *     <li>{@link SlashCommand.CooldownScope#GUILD GUILD} defaults to
-+     *     {@link SlashCommand.CooldownScope#CHANNEL CHANNEL}.</li>
-+     *     <li>{@link SlashCommand.CooldownScope#USER_GUILD USER_GUILD} defaults to
-+     *     {@link SlashCommand.CooldownScope#USER_CHANNEL USER_CHANNEL}.</li>
-+     * </ul>
-+     *
-+     * These are effective across a single instance of JDA, and not multiple
-+     * ones, save when multiple shards run on a single JVM and under a
-+     * {@link net.dv8tion.jda.api.sharding.ShardManager ShardManager}.
-+     * <br>There is no shard magic, and no guarantees for a 100% "global"
-+     * cooldown, unless all shards of the bot run under the same ShardManager,
-+     * and/or via some external system unrelated to JDA-Utilities.
-+     *
-+     * @since  1.3
-+     * @author Kaidan Gustave
-+     *
-+     * @see    SlashCommand#cooldownScope Command.cooldownScope
-+     */
-+    public enum CooldownScope
-+    {
-+        /**
-+         * Applies the cooldown to the calling {@link net.dv8tion.jda.api.entities.User User} across all
-+         * locations on this instance (IE: TextChannels, PrivateChannels, etc).
-+         *
-+         * <p>The key for this is generated in the format
-+         * <ul>
-+         *     {@code <command-name>|U:<userID>}
-+         * </ul>
-+         */
-+        USER("U:%d",""),
-+
-+        /**
-+         * Applies the cooldown to the {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel} the
-+         * command is called in.
-+         *
-+         * <p>The key for this is generated in the format
-+         * <ul>
-+         *     {@code <command-name>|C:<channelID>}
-+         * </ul>
-+         */
-+        CHANNEL("C:%d","in this channel"),
-+
-+        /**
-+         * Applies the cooldown to the calling {@link net.dv8tion.jda.api.entities.User User} local to the
-+         * {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel} the command is called in.
-+         *
-+         * <p>The key for this is generated in the format
-+         * <ul>
-+         *     {@code <command-name>|U:<userID>|C:<channelID>}
-+         * </ul>
-+         */
-+        USER_CHANNEL("U:%d|C:%d", "in this channel"),
-+
-+        /**
-+         * Applies the cooldown to the {@link net.dv8tion.jda.api.entities.Guild Guild} the command is called in.
-+         *
-+         * <p>The key for this is generated in the format
-+         * <ul>
-+         *     {@code <command-name>|G:<guildID>}
-+         * </ul>
-+         *
-+         * <p><b>NOTE:</b> This will automatically default back to {@link SlashCommand.CooldownScope#CHANNEL CooldownScope.CHANNEL}
-+         * when called in a private channel.  This is done in order to prevent internal
-+         * {@link NullPointerException NullPointerException}s from being thrown while generating cooldown keys!
-+         */
-+        GUILD("G:%d", "in this server"),
-+
-+        /**
-+         * Applies the cooldown to the calling {@link net.dv8tion.jda.api.entities.User User} local to the
-+         * {@link net.dv8tion.jda.api.entities.Guild Guild} the command is called in.
-+         *
-+         * <p>The key for this is generated in the format
-+         * <ul>
-+         *     {@code <command-name>|U:<userID>|G:<guildID>}
-+         * </ul>
-+         *
-+         * <p><b>NOTE:</b> This will automatically default back to {@link SlashCommand.CooldownScope#CHANNEL CooldownScope.CHANNEL}
-+         * when called in a private channel. This is done in order to prevent internal
-+         * {@link NullPointerException NullPointerException}s from being thrown while generating cooldown keys!
-+         */
-+        USER_GUILD("U:%d|G:%d", "in this server"),
-+
-+        /**
-+         * Applies the cooldown to the calling Shard the command is called on.
-+         *
-+         * <p>The key for this is generated in the format
-+         * <ul>
-+         *     {@code <command-name>|S:<shardID>}
-+         * </ul>
-+         *
-+         * <p><b>NOTE:</b> This will automatically default back to {@link SlashCommand.CooldownScope#GLOBAL CooldownScope.GLOBAL}
-+         * when {@link net.dv8tion.jda.api.JDA#getShardInfo() JDA#getShardInfo()} returns {@code null}.
-+         * This is done in order to prevent internal {@link NullPointerException NullPointerException}s
-+         * from being thrown while generating cooldown keys!
-+         */
-+        SHARD("S:%d", "on this shard"),
-+
-+        /**
-+         * Applies the cooldown to the calling {@link net.dv8tion.jda.api.entities.User User} on the Shard
-+         * the command is called on.
-+         *
-+         * <p>The key for this is generated in the format
-+         * <ul>
-+         *     {@code <command-name>|U:<userID>|S:<shardID>}
-+         * </ul>
-+         *
-+         * <p><b>NOTE:</b> This will automatically default back to {@link SlashCommand.CooldownScope#USER CooldownScope.USER}
-+         * when {@link net.dv8tion.jda.api.JDA#getShardInfo() JDA#getShardInfo()} returns {@code null}.
-+         * This is done in order to prevent internal {@link NullPointerException NullPointerException}s
-+         * from being thrown while generating cooldown keys!
-+         */
-+        USER_SHARD("U:%d|S:%d", "on this shard"),
-+
-+        /**
-+         * Applies this cooldown globally.
-+         *
-+         * <p>As this implies: the command will be unusable on the instance of JDA in all types of
-+         * {@link net.dv8tion.jda.api.entities.MessageChannel MessageChannel}s until the cooldown has ended.
-+         *
-+         * <p>The key for this is {@code <command-name>|globally}
-+         */
-+        GLOBAL("Global", "globally");
-+
-+        private final String format;
-+        final String errorSpecification;
-+
-+        CooldownScope(String format, String errorSpecification)
-+        {
-+            this.format = format;
-+            this.errorSpecification = errorSpecification;
-+        }
-+
-+        String genKey(String name, long id)
-+        {
-+            return genKey(name, id, -1);
-+        }
-+
-+        String genKey(String name, long idOne, long idTwo)
-+        {
-+            if(this.equals(GLOBAL))
-+                return name+"|"+format;
-+            else if(idTwo==-1)
-+                return name+"|"+String.format(format,idOne);
-+            else return name+"|"+String.format(format,idOne,idTwo);
-+        }
 +    }
 +}
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java

--- a/JDA-Utilities-Patches/0012-Slash-command-support.patch
+++ b/JDA-Utilities-Patches/0012-Slash-command-support.patch
@@ -1,4 +1,4 @@
-From 95c69c98e854493e07dc40f7cd3fbe233e36212f Mon Sep 17 00:00:00 2001
+From d2c6ed06e0a2102d6d9a78069fb667e1f468c38b Mon Sep 17 00:00:00 2001
 From: Chew <chew@chew.pw>
 Date: Sun, 23 May 2021 17:46:44 -0500
 Subject: [PATCH] Slash command support
@@ -160,27 +160,29 @@ index f8db009..76627dd 100644
       * Removes a single {@link com.jagrosh.jdautilities.command.Command Command} from this CommandClient's
       * registered Commands at the index linked to the provided name/alias.
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/CommandClientBuilder.java b/command/src/main/java/com/jagrosh/jdautilities/command/CommandClientBuilder.java
-index 6d0e434..1defeb2 100644
+index 6d0e434..939e09b 100644
 --- a/command/src/main/java/com/jagrosh/jdautilities/command/CommandClientBuilder.java
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/CommandClientBuilder.java
-@@ -54,6 +54,7 @@ public class CommandClientBuilder
+@@ -54,6 +54,9 @@ public class CommandClientBuilder
      private String carbonKey;
      private String botsKey;
      private final LinkedList<Command> commands = new LinkedList<>();
 +    private final LinkedList<SlashCommand> slashCommands = new LinkedList<>();
++    private String forcedGuildId = null;
++    private boolean manualUpsert = false;
      private CommandListener listener;
      private boolean useHelp = true;
      private boolean shutdownAutomatically = true;
-@@ -75,7 +76,7 @@ public class CommandClientBuilder
+@@ -75,7 +78,7 @@ public class CommandClientBuilder
      public CommandClient build()
      {
          CommandClient client = new CommandClientImpl(ownerId, coOwnerIds, prefix, altprefix, prefixes, prefixFunction, commandPreProcessFunction, activity, status, serverInvite,
 -                                                     success, warning, error, carbonKey, botsKey, new ArrayList<>(commands), useHelp,
-+                                                     success, warning, error, carbonKey, botsKey, new ArrayList<>(commands), new ArrayList<>(slashCommands), useHelp,
++                                                     success, warning, error, carbonKey, botsKey, new ArrayList<>(commands), new ArrayList<>(slashCommands), forcedGuildId, manualUpsert, useHelp,
                                                       shutdownAutomatically, helpConsumer, helpWord, executor, linkedCacheSize, compiler, manager);
          if(listener!=null)
              client.setListener(listener);
-@@ -346,6 +347,38 @@ public class CommandClientBuilder
+@@ -346,6 +349,66 @@ public class CommandClientBuilder
          return this;
      }
  
@@ -216,15 +218,43 @@ index 6d0e434..1defeb2 100644
 +        return this;
 +    }
 +
++    /**
++     * Forces Guild Only for SlashCommands.
++     * This is the same as setting this.guildOnly = true and this.guildId = your value for every command.
++     * Setting this to null disables the feature, but it is off by default.
++     *
++     * @param guildId the guild ID.
++     * @return This Builder
++     */
++    public CommandClientBuilder forceGuildOnly(String guildId)
++    {
++        this.forcedGuildId = guildId;
++        return this;
++    }
++
++    /**
++     * Whether or not to manually upsert slash commands.
++     * This is designed if you want to handle upserting, instead of doing it every boot.
++     * False by default.
++     *
++     * @param manualUpsert your option.
++     * @return This Builder
++     */
++    public CommandClientBuilder setManualUpsert(boolean manualUpsert)
++    {
++        this.manualUpsert = manualUpsert;
++        return this;
++    }
++
      /**
       * Adds an annotated command module to the
       * {@link com.jagrosh.jdautilities.command.impl.CommandClientImpl CommandClientImpl} for this session.
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
 new file mode 100644
-index 0000000..fa53eae
+index 0000000..1e63795
 --- /dev/null
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
-@@ -0,0 +1,390 @@
+@@ -0,0 +1,428 @@
 +/*
 + * Copyright 2016-2018 John Grosh (jagrosh) & Kaidan Gustave (TheMonitorLizard)
 + *
@@ -248,7 +278,9 @@ index 0000000..fa53eae
 +import net.dv8tion.jda.api.entities.Member;
 +import net.dv8tion.jda.api.entities.VoiceChannel;
 +import net.dv8tion.jda.api.events.interaction.SlashCommandEvent;
++import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 +import net.dv8tion.jda.api.interactions.commands.build.OptionData;
++import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
 +
 +import java.util.ArrayList;
 +import java.util.List;
@@ -308,8 +340,9 @@ index 0000000..fa53eae
 +     * This is to specify different options for arguments and the stuff.
 +     *
 +     * For example, to add an argument for "input", you can do this:<br>
-+     * <pre><code> OptionData data = new OptionData(OptionType.STRING, "input", "The input for the command").setRequired(true);
-+     *     List OptionData dataList = new ArrayList();
++     * <pre><code>
++     *     OptionData data = new OptionData(OptionType.STRING, "input", "The input for the command").setRequired(true);
++     *    {@literal List<OptionData> dataList = new ArrayList<>();}
 +     *     dataList.add(data);
 +     *     this.options = dataList;</code></pre>
 +     */
@@ -536,6 +569,41 @@ index 0000000..fa53eae
 +    }
 +
 +    /**
++     * Builds CommandData for the SlashCommand upsert.
++     * This code is executed when we need to upsert the command.
++     *
++     * Useful for manual upserting.
++     *
++     * @return the built command data
++     */
++    public CommandData buildCommandData()
++    {
++        CommandData data = new CommandData(getName(), getHelp());
++        if (!getOptions().isEmpty())
++        {
++            for (OptionData optionData : getOptions()) {
++                data.addOption(optionData);
++            }
++        }
++        if (children.length != 0)
++        {
++            for (SlashCommand child : children)
++            {
++                SubcommandData subcommandData = new SubcommandData(child.getName(), child.getHelp());
++                if (!getOptions().isEmpty())
++                {
++                    for (OptionData optionData : child.getOptions()) {
++                        subcommandData.addOption(optionData);
++                    }
++                }
++                data.addSubcommand(subcommandData);
++            }
++        }
++
++        return data;
++    }
++
++    /**
 +     * Gets the {@link SlashCommand#children Command.children} for the Command.
 +     *
 +     * @return The children for the Command
@@ -616,7 +684,7 @@ index 0000000..fa53eae
 +    }
 +}
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
-index 5a5e7d2..3976bb8 100644
+index 5a5e7d2..81af25a 100644
 --- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
 @@ -28,9 +28,12 @@ import net.dv8tion.jda.api.events.ReadyEvent;
@@ -632,7 +700,7 @@ index 5a5e7d2..3976bb8 100644
  import net.dv8tion.jda.internal.utils.Checks;
  import okhttp3.*;
  import org.json.JSONObject;
-@@ -78,7 +81,10 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -78,7 +81,12 @@ public class CommandClientImpl implements CommandClient, EventListener
      private final Function<MessageReceivedEvent, Boolean> commandPreProcessFunction;
      private final String serverInvite;
      private final HashMap<String, Integer> commandIndex;
@@ -640,19 +708,21 @@ index 5a5e7d2..3976bb8 100644
      private final ArrayList<Command> commands;
 +    private final ArrayList<SlashCommand> slashCommands;
 +    private final ArrayList<String> slashCommandIds;
++    private final String forcedGuildId;
++    private final boolean manualUpsert;
      private final String success;
      private final String warning;
      private final String error;
-@@ -99,7 +105,7 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -99,7 +107,7 @@ public class CommandClientImpl implements CommandClient, EventListener
      private int totalGuilds;
  
      public CommandClientImpl(String ownerId, String[] coOwnerIds, String prefix, String altprefix, String[] prefixes, Function<MessageReceivedEvent, String> prefixFunction, Function<MessageReceivedEvent, Boolean> commandPreProcessFunction, Activity activity, OnlineStatus status, String serverInvite,
 -                             String success, String warning, String error, String carbonKey, String botsKey, ArrayList<Command> commands,
-+                             String success, String warning, String error, String carbonKey, String botsKey, ArrayList<Command> commands, ArrayList<SlashCommand> slashCommands,
++                             String success, String warning, String error, String carbonKey, String botsKey, ArrayList<Command> commands, ArrayList<SlashCommand> slashCommands, String forcedGuildId, boolean manualUpsert,
                               boolean useHelp, boolean shutdownAutomatically, Consumer<CommandEvent> helpConsumer, String helpWord, ScheduledExecutorService executor,
                               int linkedCacheSize, AnnotatedModuleCompiler compiler, GuildSettingsManager manager)
      {
-@@ -136,7 +142,10 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -136,7 +144,12 @@ public class CommandClientImpl implements CommandClient, EventListener
          this.carbonKey = carbonKey;
          this.botsKey = botsKey;
          this.commandIndex = new HashMap<>();
@@ -660,10 +730,12 @@ index 5a5e7d2..3976bb8 100644
          this.commands = new ArrayList<>();
 +        this.slashCommands = new ArrayList<>();
 +        this.slashCommandIds = new ArrayList<>();
++        this.forcedGuildId = forcedGuildId;
++        this.manualUpsert = manualUpsert;
          this.cooldowns = new HashMap<>();
          this.uses = new HashMap<>();
          this.linkMap = linkedCacheSize>0 ? new FixedSizeCache<>(linkedCacheSize) : null;
-@@ -182,6 +191,12 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -182,6 +195,12 @@ public class CommandClientImpl implements CommandClient, EventListener
          {
              addCommand(command);
          }
@@ -676,7 +748,7 @@ index 5a5e7d2..3976bb8 100644
      }
  
      @Override
-@@ -292,6 +307,35 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -292,6 +311,35 @@ public class CommandClientImpl implements CommandClient, EventListener
          commands.add(index,command);
      }
  
@@ -712,7 +784,7 @@ index 5a5e7d2..3976bb8 100644
      @Override
      public void removeCommand(String name)
      {
-@@ -461,6 +505,9 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -461,6 +509,9 @@ public class CommandClientImpl implements CommandClient, EventListener
          if(event instanceof MessageReceivedEvent)
              onMessageReceived((MessageReceivedEvent)event);
  
@@ -722,31 +794,30 @@ index 5a5e7d2..3976bb8 100644
          else if(event instanceof GuildMessageDeleteEvent && usesLinkedDeletion())
              onMessageDelete((GuildMessageDeleteEvent) event);
  
-@@ -498,6 +545,23 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -498,6 +549,22 @@ public class CommandClientImpl implements CommandClient, EventListener
          if(manager != null)
              manager.init();
  
-+        // Upsert slash commands
-+        for (SlashCommand command : slashCommands)
++        // Upsert slash commands, if not manual
++        if (!manualUpsert)
 +        {
-+            CommandData data = new CommandData(command.getName(), command.getHelp());
-+            if (!command.getOptions().isEmpty()) {
-+                for (OptionData optionData : command.getOptions()) {
-+                    data.addOption(optionData);
-+                }
-+            }
++            for (SlashCommand command : slashCommands)
++            {
++                CommandData data = command.buildCommandData();
 +
-+            if (command.isGuildOnly() && command.getGuildId() != null) {
-+                event.getJDA().getGuildById(command.getGuildId()).upsertCommand(data).queue(command1 -> slashCommandIds.add(command1.getId()));
-+            } else {
-+                event.getJDA().upsertCommand(data).queue(command1 -> slashCommandIds.add(command1.getId()));
++                if (forcedGuildId != null || (command.isGuildOnly() && command.getGuildId() != null)) {
++                    String guildId = forcedGuildId != null ? forcedGuildId : command.getGuildId();
++                    event.getJDA().getGuildById(guildId).upsertCommand(data).queue(command1 -> slashCommandIds.add(command1.getId()));
++                } else {
++                    event.getJDA().upsertCommand(data).queue(command1 -> slashCommandIds.add(command1.getId()));
++                }
 +            }
 +        }
 +
          sendStats(event.getJDA());
      }
  
-@@ -607,6 +671,29 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -607,6 +674,29 @@ public class CommandClientImpl implements CommandClient, EventListener
              listener.onNonCommandMessage(event);
      }
  

--- a/JDA-Utilities-Patches/0012-Slash-command-support.patch
+++ b/JDA-Utilities-Patches/0012-Slash-command-support.patch
@@ -1,4 +1,4 @@
-From a53f19686185d4d2d972b8ee3dc206eaf21f427f Mon Sep 17 00:00:00 2001
+From 2aae07b34d87ae911da46a74e5ec9d7a5fad85df Mon Sep 17 00:00:00 2001
 From: Chew <chew@chew.pw>
 Date: Sun, 23 May 2021 17:46:44 -0500
 Subject: [PATCH] Slash command support
@@ -37,7 +37,7 @@ index 3a2f282..0838420 100644
              name 'm2-dv8tion'
              url 'https://m2.dv8tion.net/releases'
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/Command.java b/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
-index d8186b1..3bb63c2 100644
+index d8186b1..16891b8 100644
 --- a/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
 @@ -68,12 +68,15 @@ import net.dv8tion.jda.api.entities.VoiceChannel;
@@ -67,17 +67,18 @@ index d8186b1..3bb63c2 100644
       */
      protected String arguments = null;
      
-@@ -102,7 +107,8 @@ public abstract class Command
+@@ -102,7 +107,9 @@ public abstract class Command
      
      /**
       * {@code true} if the command may only be used by a User with an ID matching the
 -     * Owners or any of the CoOwners.
 +     * Owners or any of the CoOwners.<br>
-+     * If enabled for a Slash Command, the owners will be added to the SlashCommand.
++     * If enabled for a Slash Command, only owners (owner + up to 9 co-owners) will be added to the SlashCommand.
++     * All other permissions will be ignored.
       * <br>Default {@code false}.
       */
      protected boolean ownerCommand = false;
-@@ -127,6 +133,7 @@ public abstract class Command
+@@ -127,6 +134,7 @@ public abstract class Command
      /**
       * The aliases of the command, when calling a command these function identically to calling the
       * {@link com.jagrosh.jdautilities.command.Command#name Command.name}.
@@ -85,20 +86,17 @@ index d8186b1..3bb63c2 100644
       */
      protected String[] aliases = new String[0];
      
-@@ -152,7 +159,11 @@ public abstract class Command
+@@ -152,7 +160,8 @@ public abstract class Command
  
      /**
       * {@code true} if this command should be hidden from the help.
 -     * <br>Default {@code false}
 +     * <br>Default {@code false}<br>
-+     * If enabled for a slash command, you must give yourself permission to use it.
-+     * @see net.dv8tion.jda.api.requests.restaction.CommandCreateAction#setDefaultEnabled(boolean)
-+     * @see SlashCommand#enabledRoles
-+     * @see SlashCommand#enabledUsers
++     * <b>This has no effect for SlashCommands.</b>
       */
      protected boolean hidden = false;
  
-@@ -529,7 +540,7 @@ public abstract class Command
+@@ -529,7 +538,7 @@ public abstract class Command
      }
      
      /**
@@ -107,7 +105,7 @@ index d8186b1..3bb63c2 100644
       *
       * @return {@code true} if the command should be hidden, otherwise {@code false}
       */
-@@ -692,6 +703,7 @@ public abstract class Command
+@@ -692,6 +701,7 @@ public abstract class Command
          
          /**
           * Runs a test of the provided {@link java.util.function.Predicate}.
@@ -373,10 +371,10 @@ index f4658a8..ed93f17 100644
  }
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
 new file mode 100644
-index 0000000..44382a3
+index 0000000..9f1ecea
 --- /dev/null
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
-@@ -0,0 +1,464 @@
+@@ -0,0 +1,573 @@
 +/*
 + * Copyright 2016-2018 John Grosh (jagrosh) & Kaidan Gustave (TheMonitorLizard)
 + *
@@ -403,6 +401,8 @@ index 0000000..44382a3
 +import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 +import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 +import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
++import net.dv8tion.jda.api.interactions.commands.privileges.CommandPrivilege;
++import org.jetbrains.annotations.Nullable;
 +
 +import java.util.ArrayList;
 +import java.util.List;
@@ -453,15 +453,41 @@ index 0000000..44382a3
 +
 +    /**
 +     * The list of role IDs who can use this Slash Command.
-+     * Because command privileges are restricted to a Guild, these will not take effect for Global commands.
++     * Because command privileges are restricted to a Guild, these will not take effect for Global commands.<br>
++     * This is useless if {@link #defaultEnabled} isn't false.
 +     */
 +    protected String[] enabledRoles = new String[]{};
 +
 +    /**
 +     * The list of user IDs who can use this Slash Command.
-+     * Because command privileges are restricted to a Guild, these will not take effect for Global commands.
++     * Because command privileges are restricted to a Guild, these will not take effect for Global commands.<br>
++     * This is useless if {@link #defaultEnabled} isn't false.
 +     */
 +    protected String[] enabledUsers = new String[]{};
++
++    /**
++     * The list of role IDs who cannot use this Slash Command.
++     * Because command privileges are restricted to a Guild, these will not take effect for Global commands.<br>
++     * This is useless if {@link #defaultEnabled} isn't true.
++     */
++    protected String[] disabledRoles = new String[]{};
++
++    /**
++     * The list of user IDs who cannot use this Slash Command.
++     * Because command privileges are restricted to a Guild, these will not take effect for Global commands.<br>
++     * This is useless if {@link #defaultEnabled} isn't true.
++     */
++    protected String[] disabledUsers = new String[]{};
++
++    /**
++     * Whether or not this command is disabled by default.
++     * If disabled, you must give yourself permission to use it.<br>
++     * In order for {@link #enabledUsers} and {@link #enabledRoles} to work, this must be set to false.
++     * @see net.dv8tion.jda.api.requests.restaction.CommandCreateAction#setDefaultEnabled(boolean)
++     * @see SlashCommand#enabledRoles
++     * @see SlashCommand#enabledUsers
++     */
++    protected boolean defaultEnabled = true;
 +
 +    /**
 +     * The child commands of the command. These are used in the format {@code /<parent name>
@@ -541,7 +567,7 @@ index 0000000..44382a3
 +        // owner check
 +        if(ownerCommand && !(isOwner(event, client)))
 +        {
-+            terminate(event,null, client);
++            terminate(event,"Only an owner may run this command. Sorry.", client);
 +            return;
 +        }
 +
@@ -702,7 +728,7 @@ index 0000000..44382a3
 +
 +    /**
 +     * Gets the enabled roles for this Slash Command.
-+     * A user MUST have a role for a command to show up.
++     * A user MUST have a role for a command to be ran.
 +     *
 +     * @return a list of String role IDs
 +     */
@@ -712,14 +738,50 @@ index 0000000..44382a3
 +    }
 +
 +    /**
-+     * Gets the enabled roles for this Slash Command.
-+     * A user with an ID in this list is required for the command to show up.
++     * Gets the enabled users for this Slash Command.
++     * A user with an ID in this list is required for the command to be ran.
 +     *
 +     * @return a list of String user IDs
 +     */
 +    public String[] getEnabledUsers()
 +    {
 +        return enabledUsers;
++    }
++
++    /**
++     * Gets the disabled roles for this Slash Command.
++     * A user with this role may not run this command.
++     *
++     * @return a list of String role IDs
++     */
++    public String[] getDisabledRoles()
++    {
++        return disabledRoles;
++    }
++
++    /**
++     * Gets the disabled users for this Slash Command.
++     * Uses in this list may not run this command.
++     *
++     * @return a list of String user IDs
++     */
++    public String[] getDisabledUsers()
++    {
++        return disabledUsers;
++    }
++
++
++    /**
++     * Whether or not this command is enabled by default.
++     * If disabled by default, you MUST enable {@link #enabledRoles roles}
++     * or {@link #enabledUsers users} to access it.
++     * This does NOT hide it, it simply appears greyed out.
++     *
++     * @return a list of String user IDs
++     */
++    public boolean isDefaultEnabled()
++    {
++        return defaultEnabled;
 +    }
 +
 +    /**
@@ -760,7 +822,52 @@ index 0000000..44382a3
 +            }
 +        }
 +
++        // Default enabled is synonymous with hidden now.
++        data.setDefaultEnabled(isDefaultEnabled());
++
 +        return data;
++    }
++
++    /**
++     * Builds CommandPrivilege for the SlashCommand permissions.
++     * This code is executed after upsertion to update the permissions.
++     * <br>
++     * <b>The max amount of privilege is 10, keep this in mind.</b>
++     *
++     * Useful for manual upserting.
++     *
++     * @param client the command client for owner checking.
++     *               if null, owner checks won't be performed
++     * @return the built privilege data
++     */
++    public List<CommandPrivilege> buildPrivileges(@Nullable CommandClient client)
++    {
++        List<CommandPrivilege> privileges = new ArrayList<>();
++        // Privilege Checks
++        for (String role : getEnabledRoles())
++            privileges.add(CommandPrivilege.enableRole(role));
++        for (String user : getEnabledUsers())
++            privileges.add(CommandPrivilege.enableUser(user));
++        for (String role : getDisabledRoles())
++            privileges.add(CommandPrivilege.disableRole(role));
++        for (String user : getDisabledUsers())
++            privileges.add(CommandPrivilege.disableUser(user));
++        // Co/Owner checks
++        if (isOwnerCommand() && client != null)
++        {
++            // Clear array, we have the priority here.
++            privileges.clear();
++            // Add owner
++            privileges.add(CommandPrivilege.enableUser(client.getOwnerId()));
++            // Add co-owners
++            for (String user : client.getCoOwnerIds())
++                privileges.add(CommandPrivilege.enableUser(user));
++        }
++
++        if (privileges.size() > 10)
++            privileges = privileges.subList(0, 10);
++
++        return privileges;
 +    }
 +
 +    /**
@@ -842,7 +949,7 @@ index 0000000..44382a3
 +    }
 +}
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
-index 5a5e7d2..7a20bb7 100644
+index 5a5e7d2..9ded2f3 100644
 --- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
 @@ -28,9 +28,12 @@ import net.dv8tion.jda.api.events.ReadyEvent;
@@ -952,7 +1059,7 @@ index 5a5e7d2..7a20bb7 100644
          else if(event instanceof GuildMessageDeleteEvent && usesLinkedDeletion())
              onMessageDelete((GuildMessageDeleteEvent) event);
  
-@@ -498,6 +549,48 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -498,6 +549,32 @@ public class CommandClientImpl implements CommandClient, EventListener
          if(manager != null)
              manager.init();
  
@@ -963,24 +1070,6 @@ index 5a5e7d2..7a20bb7 100644
 +            {
 +                CommandData data = command.buildCommandData();
 +
-+                List<CommandPrivilege> privileges = new ArrayList<>();
-+                // Privilege Checks
-+                for (String role : command.getEnabledRoles())
-+                    privileges.add(CommandPrivilege.enableRole(role));
-+                for (String user : command.getEnabledRoles())
-+                    privileges.add(CommandPrivilege.enableUser(user));
-+                // Co/Owner checks
-+                if (command.isOwnerCommand())
-+                {
-+                    // Add owner
-+                    privileges.add(CommandPrivilege.enableUser(getOwnerId()));
-+                    // Add co-owners
-+                    for (String user : getCoOwnerIds())
-+                        privileges.add(CommandPrivilege.enableUser(user));
-+                }
-+                // Default enabled is synonymous with hidden now.
-+                data.setDefaultEnabled(command.isHidden());
-+
 +                if (forcedGuildId != null || (command.isGuildOnly() && command.getGuildId() != null)) {
 +                    String guildId = forcedGuildId != null ? forcedGuildId : command.getGuildId();
 +                    Guild guild = event.getJDA().getGuildById(guildId);
@@ -988,9 +1077,11 @@ index 5a5e7d2..7a20bb7 100644
 +                        LOG.error("Could not find guild with specified ID: " + forcedGuildId + ". Not going to upsert.");
 +                        continue;
 +                    }
++                    List<CommandPrivilege> privileges = command.buildPrivileges(this);
 +                    guild.upsertCommand(data).queue(command1 -> {
 +                        slashCommandIds.add(command1.getId());
-+                        command1.updatePrivileges(guild, privileges).queue();
++                        if (!privileges.isEmpty())
++                            command1.updatePrivileges(guild, privileges).queue();
 +                    });
 +                } else {
 +                    event.getJDA().upsertCommand(data).queue(command1 -> slashCommandIds.add(command1.getId()));
@@ -1001,7 +1092,7 @@ index 5a5e7d2..7a20bb7 100644
          sendStats(event.getJDA());
      }
  
-@@ -607,6 +700,25 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -607,6 +684,25 @@ public class CommandClientImpl implements CommandClient, EventListener
              listener.onNonCommandMessage(event);
      }
  

--- a/JDA-Utilities-Patches/0012-Slash-command-support.patch
+++ b/JDA-Utilities-Patches/0012-Slash-command-support.patch
@@ -1,11 +1,11 @@
-From a599f9fc91ff804c0b7a0949df516df8f7a3ce24 Mon Sep 17 00:00:00 2001
+From a53f19686185d4d2d972b8ee3dc206eaf21f427f Mon Sep 17 00:00:00 2001
 From: Chew <chew@chew.pw>
 Date: Sun, 23 May 2021 17:46:44 -0500
 Subject: [PATCH] Slash command support
 
 
 diff --git a/build.gradle b/build.gradle
-index 3a2f282..022d22e 100644
+index 3a2f282..0838420 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -35,7 +35,7 @@ allprojects {
@@ -13,7 +13,7 @@ index 3a2f282..022d22e 100644
  
      ext {
 -        jdaVersion = '4.2.1_255'
-+        jdaVersion = 'feature~slash-commands-SNAPSHOT'
++        jdaVersion = '757de9be45'
          slf4jVersion = '1.7.25'
          okhttpVersion = '3.13.0'
          findbugsVersion = '3.0.2'
@@ -37,7 +37,7 @@ index 3a2f282..022d22e 100644
              name 'm2-dv8tion'
              url 'https://m2.dv8tion.net/releases'
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/Command.java b/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
-index d8186b1..ed2dcf0 100644
+index d8186b1..3bb63c2 100644
 --- a/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
 @@ -68,12 +68,15 @@ import net.dv8tion.jda.api.entities.VoiceChannel;
@@ -67,7 +67,17 @@ index d8186b1..ed2dcf0 100644
       */
      protected String arguments = null;
      
-@@ -127,6 +132,7 @@ public abstract class Command
+@@ -102,7 +107,8 @@ public abstract class Command
+     
+     /**
+      * {@code true} if the command may only be used by a User with an ID matching the
+-     * Owners or any of the CoOwners.
++     * Owners or any of the CoOwners.<br>
++     * If enabled for a Slash Command, the owners will be added to the SlashCommand.
+      * <br>Default {@code false}.
+      */
+     protected boolean ownerCommand = false;
+@@ -127,6 +133,7 @@ public abstract class Command
      /**
       * The aliases of the command, when calling a command these function identically to calling the
       * {@link com.jagrosh.jdautilities.command.Command#name Command.name}.
@@ -75,15 +85,29 @@ index d8186b1..ed2dcf0 100644
       */
      protected String[] aliases = new String[0];
      
-@@ -153,6 +159,7 @@ public abstract class Command
+@@ -152,7 +159,11 @@ public abstract class Command
+ 
      /**
       * {@code true} if this command should be hidden from the help.
-      * <br>Default {@code false}
-+     * This won't work for Slash Commands, as they will always show up.
+-     * <br>Default {@code false}
++     * <br>Default {@code false}<br>
++     * If enabled for a slash command, you must give yourself permission to use it.
++     * @see net.dv8tion.jda.api.requests.restaction.CommandCreateAction#setDefaultEnabled(boolean)
++     * @see SlashCommand#enabledRoles
++     * @see SlashCommand#enabledUsers
       */
      protected boolean hidden = false;
  
-@@ -692,6 +699,7 @@ public abstract class Command
+@@ -529,7 +540,7 @@ public abstract class Command
+     }
+     
+     /**
+-     * Checks whether or not this command should be hidden from the help
++     * Checks whether or not this command should be hidden from the help or disabled by default (SlashCommands)
+      *
+      * @return {@code true} if the command should be hidden, otherwise {@code false}
+      */
+@@ -692,6 +703,7 @@ public abstract class Command
          
          /**
           * Runs a test of the provided {@link java.util.function.Predicate}.
@@ -349,10 +373,10 @@ index f4658a8..ed93f17 100644
  }
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
 new file mode 100644
-index 0000000..78737ec
+index 0000000..44382a3
 --- /dev/null
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
-@@ -0,0 +1,425 @@
+@@ -0,0 +1,464 @@
 +/*
 + * Copyright 2016-2018 John Grosh (jagrosh) & Kaidan Gustave (TheMonitorLizard)
 + *
@@ -420,6 +444,26 @@ index 0000000..78737ec
 +public abstract class SlashCommand extends Command
 +{
 +    /**
++     * This option is deprecated in favor of {@link #enabledRoles}
++     * Please replace this with this.enabledRoles = new String[]{Roles};
++     * While this check is still done, it's better to let Discord do the work.
++     */
++    @Deprecated
++    protected String requiredRole = null;
++
++    /**
++     * The list of role IDs who can use this Slash Command.
++     * Because command privileges are restricted to a Guild, these will not take effect for Global commands.
++     */
++    protected String[] enabledRoles = new String[]{};
++
++    /**
++     * The list of user IDs who can use this Slash Command.
++     * Because command privileges are restricted to a Guild, these will not take effect for Global commands.
++     */
++    protected String[] enabledUsers = new String[]{};
++
++    /**
 +     * The child commands of the command. These are used in the format {@code /<parent name>
 +     * <child name>}.
 +     */
@@ -469,6 +513,7 @@ index 0000000..78737ec
 +     * <b>
 +     *     Because this is a SlashCommand, this is called, but does nothing.
 +     *     You can still override this if you want to have a separate response for normal [prefix][name].
++     *     Keep in mind you must add it as a Command via {@link CommandClientBuilder#addCommand(Command)} for it to work properly.
 +     * </b>
 +     *
 +     * @param  event
@@ -656,6 +701,28 @@ index 0000000..78737ec
 +    }
 +
 +    /**
++     * Gets the enabled roles for this Slash Command.
++     * A user MUST have a role for a command to show up.
++     *
++     * @return a list of String role IDs
++     */
++    public String[] getEnabledRoles()
++    {
++        return enabledRoles;
++    }
++
++    /**
++     * Gets the enabled roles for this Slash Command.
++     * A user with an ID in this list is required for the command to show up.
++     *
++     * @return a list of String user IDs
++     */
++    public String[] getEnabledUsers()
++    {
++        return enabledUsers;
++    }
++
++    /**
 +     * Gets the options associated with this command.
 +     *
 +     * @return the OptionData array for options
@@ -678,9 +745,7 @@ index 0000000..78737ec
 +        CommandData data = new CommandData(getName(), getHelp());
 +        if (!getOptions().isEmpty())
 +        {
-+            for (OptionData optionData : getOptions()) {
-+                data.addOption(optionData);
-+            }
++            data.addOptions(getOptions());
 +        }
 +        if (children.length != 0)
 +        {
@@ -689,11 +754,9 @@ index 0000000..78737ec
 +                SubcommandData subcommandData = new SubcommandData(child.getName(), child.getHelp());
 +                if (!getOptions().isEmpty())
 +                {
-+                    for (OptionData optionData : child.getOptions()) {
-+                        subcommandData.addOption(optionData);
-+                    }
++                    subcommandData.addOptions(child.getOptions());
 +                }
-+                data.addSubcommand(subcommandData);
++                data.addSubcommands(subcommandData);
 +            }
 +        }
 +
@@ -779,7 +842,7 @@ index 0000000..78737ec
 +    }
 +}
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
-index 5a5e7d2..4c9a949 100644
+index 5a5e7d2..7a20bb7 100644
 --- a/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/impl/CommandClientImpl.java
 @@ -28,9 +28,12 @@ import net.dv8tion.jda.api.events.ReadyEvent;
@@ -791,7 +854,7 @@ index 5a5e7d2..4c9a949 100644
  import net.dv8tion.jda.api.events.message.guild.GuildMessageDeleteEvent;
  import net.dv8tion.jda.api.hooks.EventListener;
 +import net.dv8tion.jda.api.interactions.commands.build.CommandData;
-+import net.dv8tion.jda.api.interactions.commands.build.OptionData;
++import net.dv8tion.jda.api.interactions.commands.privileges.CommandPrivilege;
  import net.dv8tion.jda.internal.utils.Checks;
  import okhttp3.*;
  import org.json.JSONObject;
@@ -889,7 +952,7 @@ index 5a5e7d2..4c9a949 100644
          else if(event instanceof GuildMessageDeleteEvent && usesLinkedDeletion())
              onMessageDelete((GuildMessageDeleteEvent) event);
  
-@@ -498,6 +549,22 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -498,6 +549,48 @@ public class CommandClientImpl implements CommandClient, EventListener
          if(manager != null)
              manager.init();
  
@@ -900,9 +963,35 @@ index 5a5e7d2..4c9a949 100644
 +            {
 +                CommandData data = command.buildCommandData();
 +
++                List<CommandPrivilege> privileges = new ArrayList<>();
++                // Privilege Checks
++                for (String role : command.getEnabledRoles())
++                    privileges.add(CommandPrivilege.enableRole(role));
++                for (String user : command.getEnabledRoles())
++                    privileges.add(CommandPrivilege.enableUser(user));
++                // Co/Owner checks
++                if (command.isOwnerCommand())
++                {
++                    // Add owner
++                    privileges.add(CommandPrivilege.enableUser(getOwnerId()));
++                    // Add co-owners
++                    for (String user : getCoOwnerIds())
++                        privileges.add(CommandPrivilege.enableUser(user));
++                }
++                // Default enabled is synonymous with hidden now.
++                data.setDefaultEnabled(command.isHidden());
++
 +                if (forcedGuildId != null || (command.isGuildOnly() && command.getGuildId() != null)) {
 +                    String guildId = forcedGuildId != null ? forcedGuildId : command.getGuildId();
-+                    event.getJDA().getGuildById(guildId).upsertCommand(data).queue(command1 -> slashCommandIds.add(command1.getId()));
++                    Guild guild = event.getJDA().getGuildById(guildId);
++                    if (guild == null) {
++                        LOG.error("Could not find guild with specified ID: " + forcedGuildId + ". Not going to upsert.");
++                        continue;
++                    }
++                    guild.upsertCommand(data).queue(command1 -> {
++                        slashCommandIds.add(command1.getId());
++                        command1.updatePrivileges(guild, privileges).queue();
++                    });
 +                } else {
 +                    event.getJDA().upsertCommand(data).queue(command1 -> slashCommandIds.add(command1.getId()));
 +                }
@@ -912,7 +1001,7 @@ index 5a5e7d2..4c9a949 100644
          sendStats(event.getJDA());
      }
  
-@@ -607,6 +674,25 @@ public class CommandClientImpl implements CommandClient, EventListener
+@@ -607,6 +700,25 @@ public class CommandClientImpl implements CommandClient, EventListener
              listener.onNonCommandMessage(event);
      }
  

--- a/JDA-Utilities-Patches/0012-Slash-command-support.patch
+++ b/JDA-Utilities-Patches/0012-Slash-command-support.patch
@@ -1,23 +1,23 @@
-From e606a0c8615d377c67decfce1cc7a25e8649281f Mon Sep 17 00:00:00 2001
+From a599f9fc91ff804c0b7a0949df516df8f7a3ce24 Mon Sep 17 00:00:00 2001
 From: Chew <chew@chew.pw>
 Date: Sun, 23 May 2021 17:46:44 -0500
 Subject: [PATCH] Slash command support
 
 
 diff --git a/build.gradle b/build.gradle
-index 0b5d4e2..8d89cce 100644
+index 3a2f282..022d22e 100644
 --- a/build.gradle
 +++ b/build.gradle
-@@ -37,7 +37,7 @@ allprojects {
+@@ -35,7 +35,7 @@ allprojects {
      version = versionInfo.values().join('.')
  
      ext {
--        jdaVersion = '4.2.0_214'
+-        jdaVersion = '4.2.1_255'
 +        jdaVersion = 'feature~slash-commands-SNAPSHOT'
          slf4jVersion = '1.7.25'
          okhttpVersion = '3.13.0'
          findbugsVersion = '3.0.2'
-@@ -45,7 +45,7 @@ allprojects {
+@@ -43,7 +43,7 @@ allprojects {
          junitVersion = '4.13.1' // TODO Move to junit 5?
  
          dependencies {
@@ -26,16 +26,16 @@ index 0b5d4e2..8d89cce 100644
              slf4j = { [group: 'org.slf4j', name: 'slf4j-api', version: slf4jVersion] }
              okhttp = { [group: 'com.squareup.okhttp3', name: 'okhttp', version: okhttpVersion] }
              findbugs = { [group: 'com.google.code.findbugs', name: 'jsr305', version: findbugsVersion] }
-@@ -92,6 +92,9 @@ allprojects {
- 
-     repositories {
-         jcenter()
-+        maven { url 'https://jitpack.io' }
-+        mavenCentral()
-+        mavenLocal()
+@@ -89,7 +89,9 @@ allprojects {
      }
  
-     build {
+     repositories {
++        maven { url 'https://jitpack.io' }
+         mavenCentral()
++        mavenLocal()
+         maven {
+             name 'm2-dv8tion'
+             url 'https://m2.dv8tion.net/releases'
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/Command.java b/command/src/main/java/com/jagrosh/jdautilities/command/Command.java
 index d8186b1..ed2dcf0 100644
 --- a/command/src/main/java/com/jagrosh/jdautilities/command/Command.java

--- a/JDA-Utilities-Patches/0012-Slash-command-support.patch
+++ b/JDA-Utilities-Patches/0012-Slash-command-support.patch
@@ -1,11 +1,11 @@
-From 2aae07b34d87ae911da46a74e5ec9d7a5fad85df Mon Sep 17 00:00:00 2001
+From 19e8ab8429d140ae59ddcd12f20854908ce8640a Mon Sep 17 00:00:00 2001
 From: Chew <chew@chew.pw>
 Date: Sun, 23 May 2021 17:46:44 -0500
 Subject: [PATCH] Slash command support
 
 
 diff --git a/build.gradle b/build.gradle
-index 3a2f282..0838420 100644
+index 3a2f282..f2e4331 100644
 --- a/build.gradle
 +++ b/build.gradle
 @@ -35,7 +35,7 @@ allprojects {
@@ -13,7 +13,7 @@ index 3a2f282..0838420 100644
  
      ext {
 -        jdaVersion = '4.2.1_255'
-+        jdaVersion = '757de9be45'
++        jdaVersion = '3846f8c'
          slf4jVersion = '1.7.25'
          okhttpVersion = '3.13.0'
          findbugsVersion = '3.0.2'
@@ -371,10 +371,10 @@ index f4658a8..ed93f17 100644
  }
 diff --git a/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
 new file mode 100644
-index 0000000..9f1ecea
+index 0000000..cb80ade
 --- /dev/null
 +++ b/command/src/main/java/com/jagrosh/jdautilities/command/SlashCommand.java
-@@ -0,0 +1,573 @@
+@@ -0,0 +1,638 @@
 +/*
 + * Copyright 2016-2018 John Grosh (jagrosh) & Kaidan Gustave (TheMonitorLizard)
 + *
@@ -401,11 +401,14 @@ index 0000000..9f1ecea
 +import net.dv8tion.jda.api.interactions.commands.build.CommandData;
 +import net.dv8tion.jda.api.interactions.commands.build.OptionData;
 +import net.dv8tion.jda.api.interactions.commands.build.SubcommandData;
++import net.dv8tion.jda.api.interactions.commands.build.SubcommandGroupData;
 +import net.dv8tion.jda.api.interactions.commands.privileges.CommandPrivilege;
 +import org.jetbrains.annotations.Nullable;
 +
 +import java.util.ArrayList;
++import java.util.HashMap;
 +import java.util.List;
++import java.util.Map;
 +
 +/**
 + * <h1><b>Slash Commands In JDA-Chewtils</b></h1>
@@ -446,7 +449,8 @@ index 0000000..9f1ecea
 +    /**
 +     * This option is deprecated in favor of {@link #enabledRoles}
 +     * Please replace this with this.enabledRoles = new String[]{Roles};
-+     * While this check is still done, it's better to let Discord do the work.
++     * While this check is still done, it's better to let Discord do the work.<br>
++     * This deprecation can be ignored if you intend to support normal and slash commands.
 +     */
 +    @Deprecated
 +    protected String requiredRole = null;
@@ -492,6 +496,7 @@ index 0000000..9f1ecea
 +    /**
 +     * The child commands of the command. These are used in the format {@code /<parent name>
 +     * <child name>}.
++     * This is synonymous with sub commands. Additionally, sub-commands cannot have children.<br>
 +     */
 +    protected SlashCommand[] children = new SlashCommand[0];
 +
@@ -503,7 +508,22 @@ index 0000000..9f1ecea
 +    protected String guildId = null;
 +
 +    /**
++     * The subcommand/child group this is associated with.
++     * Will be in format {@code /<parent name> <subcommandGroup name> <subcommand name>}.
++     *
++     * <b>This only works in a child/subcommand.</b>
++     *
++     * To instantiate: <code>{@literal new SubcommandGroupData(name, description)}</code><br>
++     * It's important the instantiations are the same across children if you intend to keep them in the same group.
++     *
++     * Can be null, and it will not be assigned to a group.
++     */
++    protected SubcommandGroupData subcommandGroup = null;
++
++    /**
 +     * An array list of OptionData.
++     *
++     * <b>This is incompatible with children. You cannot have a child AND options.</b>
 +     *
 +     * This is to specify different options for arguments and the stuff.
 +     *
@@ -563,6 +583,19 @@ index 0000000..9f1ecea
 +    {
 +        // set the client
 +        this.client = client;
++
++        // child check
++        if(event.getSubcommandName() != null)
++        {
++            for(SlashCommand cmd: children)
++            {
++                if(cmd.isCommandFor(event.getSubcommandName()))
++                {
++                    cmd.run(event, client);
++                    return;
++                }
++            }
++        }
 +
 +        // owner check
 +        if(ownerCommand && !(isOwner(event, client)))
@@ -770,7 +803,6 @@ index 0000000..9f1ecea
 +        return disabledUsers;
 +    }
 +
-+
 +    /**
 +     * Whether or not this command is enabled by default.
 +     * If disabled by default, you MUST enable {@link #enabledRoles roles}
@@ -782,6 +814,16 @@ index 0000000..9f1ecea
 +    public boolean isDefaultEnabled()
 +    {
 +        return defaultEnabled;
++    }
++
++    /**
++     * Gets the subcommand data associated with this subcommand.
++     *
++     * @return subcommand data
++     */
++    public SubcommandGroupData getSubcommandGroup()
++    {
++        return subcommandGroup;
 +    }
 +
 +    /**
@@ -804,22 +846,45 @@ index 0000000..9f1ecea
 +     */
 +    public CommandData buildCommandData()
 +    {
++        // Make the command data
 +        CommandData data = new CommandData(getName(), getHelp());
 +        if (!getOptions().isEmpty())
 +        {
 +            data.addOptions(getOptions());
 +        }
++        // Check for children
 +        if (children.length != 0)
 +        {
++            // Temporary map for easy group storage
++            Map<String, SubcommandGroupData> groupData = new HashMap<>();
 +            for (SlashCommand child : children)
 +            {
++                // Create subcommand data
 +                SubcommandData subcommandData = new SubcommandData(child.getName(), child.getHelp());
++                // Add options
 +                if (!getOptions().isEmpty())
 +                {
 +                    subcommandData.addOptions(child.getOptions());
 +                }
-+                data.addSubcommands(subcommandData);
++
++                // If there's a subcommand group
++                if (child.getSubcommandGroup() != null)
++                {
++                    SubcommandGroupData group = child.getSubcommandGroup();
++
++                    SubcommandGroupData newData = groupData.getOrDefault(group.getName(), group)
++                        .addSubcommands(subcommandData);
++
++                    groupData.put(group.getName(), newData);
++                }
++                // Just add to the command
++                else
++                {
++                    data.addSubcommands(subcommandData);
++                }
 +            }
++            if (!groupData.isEmpty())
++                data.addSubcommandGroups(groupData.values());
 +        }
 +
 +        // Default enabled is synonymous with hidden now.


### PR DESCRIPTION
THE CHUNKIEST PATCH IN EXISTENCE.

This adds support for Slash Commands. Phew!

Currently, this uses JDA's `feature/slash-commands` branch so this will be put on this repo's `feature/slash-commands`.

There's still a bit more to do, but it's pretty much done.

If you would like to test, you need to switch to my m2 repo:

```xml
        <repository>
            <id>chew-m2</id>
            <url>https://m2.chew.pro/snapshots/</url>
        </repository>
```
```xml
        <dependency>
            <groupId>pw.chew</groupId>
            <artifactId>jda-chewtils</artifactId>
            <version>1.20-SNAPSHOT</version>
            <scope>compile</scope>
            <type>pom</type>
        </dependency>
```

Check the [wiki](https://github.com/Chew/JDA-Chewtils/wiki/Command-to-SlashCommand-Migration) for migration guide.

